### PR TITLE
Improve /slurm directory structure

### DIFF
--- a/slurm/0_Introductory/BasicExample.sh
+++ b/slurm/0_Introductory/BasicExample.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/0_Introductory/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/0_Introductory/README.md
+++ b/slurm/0_Introductory/README.md
@@ -1,7 +1,5 @@
 # Basic Slurm Job
 
-## Using these examples
-
 The example Slurm script [BasicExample.sh](BasicExample.sh) can be used to submit a basic job in an HPC environment. It highlights key features such as cluster, partition, memory requirements, and more.
 
 For additional SLURM directives, refer to [slurm-options.sh](../slurm-options.sh) 
@@ -10,9 +8,9 @@ For additional SLURM directives, refer to [slurm-options.sh](../slurm-options.sh
 
 Portions of the example batch scripts which must be changed for the script to function are referred to as placeholders and denoted by square brackets. Replace the following placeholders in your script with details specific to your use case before submitting your job.
 
-- `[cluster]`: ub-hpc, faculty
-- `[partition]`: general-compute, debug, industry, scavenger, ub-laser, [other available options](https://docs.ccr.buffalo.edu/en/latest/hpc/clusters/#ub-hpc-compute-cluster)
-- `[qos]`: usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos)
-- `[SlurmAccountName]`: Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to.
-
-
+| Placeholder             | Options |
+|-------------------------|-------------------------------------------|
+| `[cluster]`             | ub-hpc, faculty |
+| `[partition]`           | general-compute, debug, industry, scavenger, ub-laser, [other available options](https://docs.ccr.buffalo.edu/en/latest/hpc/clusters/#ub-hpc-compute-cluster) |
+| `[qos]`                 | usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) |
+| `[SlurmAccountName]`    | Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to |

--- a/slurm/0_Introductory/README.md
+++ b/slurm/0_Introductory/README.md
@@ -1,16 +1,11 @@
 # Basic Slurm Job
 
-The example Slurm script [BasicExample.sh](BasicExample.sh) can be used to submit a basic job in an HPC environment. It highlights key features such as cluster, partition, memory requirements, and more.
+The example Slurm script [BasicExample.sh](BasicExample.sh) can be used to submit a basic job in an HPC environment. It highlights key features such as cluster, partition, memory requirements, and more. The `echo` statement on line 25 is an example of a command being run; this is where you would include whatever commands you want your job to execute.
 
-For additional SLURM directives, refer to [slurm-options.sh](../slurm-options.sh) 
+## Additional Information
 
-## Placeholders:
+For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
 
-Portions of the example batch scripts which must be changed for the script to function are referred to as placeholders and denoted by square brackets. Replace the following placeholders in your script with details specific to your use case before submitting your job.
-
-| Placeholder             | Options |
-|-------------------------|-------------------------------------------|
-| `[cluster]`             | ub-hpc, faculty |
-| `[partition]`           | general-compute, debug, industry, scavenger, ub-laser, [other available options](https://docs.ccr.buffalo.edu/en/latest/hpc/clusters/#ub-hpc-compute-cluster) |
-| `[qos]`                 | usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) |
-| `[SlurmAccountName]`    | Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to |
+- [Slurm README](../README.md)
+- [Placeholder Guide](../README.md#placeholders)
+- [slurm-options.sh](../slurm-options.sh)

--- a/slurm/0_Introductory/README.md
+++ b/slurm/0_Introductory/README.md
@@ -4,8 +4,6 @@ The example Slurm script [BasicExample.sh](BasicExample.sh) can be used to submi
 
 ## Additional Information
 
-For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
-
-- [Slurm README](../README.md)
-- [Placeholder Guide](../README.md#placeholders)
-- [slurm-options.sh](../slurm-options.sh)
+- The [Slurm README](../README.md) provides details on general Slurm usage.
+- The [Placeholders](../README.md#placeholders) section lists the available options for each placeholder used in the example scripts.
+- The [slurm-options.sh](../slurm-options.sh) file outlines commonly used `#SBATCH` directives with their descriptions.

--- a/slurm/2_ApplicationSpecific/README.md
+++ b/slurm/2_ApplicationSpecific/README.md
@@ -10,7 +10,7 @@ For additional SLURM directives, refer to [slurm-options.sh](../slurm-options.sh
 
 | Topic                                | Description |
 |--------------------------------------|------------------------|
-| [AlphaFold](./2_ApplicationSpecific/alphafold)                | AlphaFold example |
-| [LSDYNA](./2_ApplicationSpecific/lsdyna)                      | LSDYNA example |
-| [MATLAB](./2_ApplicationSpecific/matlab)                      | The MATLAB directory includes example scripts for running [serial](./2_ApplicationSpecific/matlab/serial), [multithreaded](./2_ApplicationSpecific/matlab/multithreaded), and [GPU](./2_ApplicationSpecific/matlab/GPU) MATLAB jobs |
-| [Python](./2_ApplicationSpecific/python)                      | A directory containing examples of [serial](./2_ApplicationSpecific/python/serial) Python job, with multithreaded and GPU examples coming soon |
+| [AlphaFold](./alphafold)                | AlphaFold example |
+| [LSDYNA](./lsdyna)                      | LSDYNA example |
+| [MATLAB](./matlab)                      | The MATLAB directory includes example scripts for running [serial](./matlab/serial), [multithreaded](./matlab/multithreaded), and [GPU](./matlab/GPU) MATLAB jobs |
+| [Python](./python)                      | A directory containing examples of [serial](./python/serial) Python job, with multithreaded and GPU examples coming soon |

--- a/slurm/2_ApplicationSpecific/README.md
+++ b/slurm/2_ApplicationSpecific/README.md
@@ -9,7 +9,7 @@ This directory contains batch scripts for a variety of applications that have sp
 | Topic                                | Description |
 |--------------------------------------|------------------------|
 | [AlphaFold](./alphafold)                | AlphFold example including a dataset for testing and validation |
-| [LSDYNA](./lsdyna)                      | LSDYNA examples for both single and multi node message passing parallel jobs as well as single node shared memory parallel jobs (See [README](./lsdyna/README.md) |
+| [LSDYNA](./lsdyna)                      | LSDYNA examples for both single and multi node message passing parallel jobs as well as single node shared memory parallel jobs (See [README](./lsdyna/README.md) for details) |
 | [MATLAB](./matlab)                      | The MATLAB directory includes example bash scripts and MATLAB functions for running [serial](./matlab/serial), [multithreaded](./matlab/multithreaded), and [GPU](./matlab/GPU) MATLAB jobs |
 | [Python](./python)                      | The Python directory includes examples bash scripts and Python functions for [serial](./python/serial) Python job, with multithreaded and GPU examples coming soon |
 

--- a/slurm/2_ApplicationSpecific/README.md
+++ b/slurm/2_ApplicationSpecific/README.md
@@ -4,13 +4,19 @@
 
 This directory contains batch scripts for a variety of applications that have special setup requirements.  You will not find an example script for every piece of software installed on CCR's systems.  These examples should be used as guidance and are not set in stone.  Please start with these examples, test for your own use case, and scale as required.
 
-For additional SLURM directives, refer to [slurm-options.sh](../slurm-options.sh) 
-
 ## Table of Topics
 
 | Topic                                | Description |
 |--------------------------------------|------------------------|
-| [AlphaFold](./alphafold)                | AlphaFold example |
-| [LSDYNA](./lsdyna)                      | LSDYNA example |
-| [MATLAB](./matlab)                      | The MATLAB directory includes example scripts for running [serial](./matlab/serial), [multithreaded](./matlab/multithreaded), and [GPU](./matlab/GPU) MATLAB jobs |
-| [Python](./python)                      | A directory containing examples of [serial](./python/serial) Python job, with multithreaded and GPU examples coming soon |
+| [AlphaFold](./alphafold)                | AlphFold example including a dataset for testing and validation |
+| [LSDYNA](./lsdyna)                      | LSDYNA examples for both single and multi node message passing parallel jobs as well as single node shared memory parallel jobs (See [README](./lsdyna/README.md) |
+| [MATLAB](./matlab)                      | The MATLAB directory includes example bash scripts and MATLAB functions for running [serial](./matlab/serial), [multithreaded](./matlab/multithreaded), and [GPU](./matlab/GPU) MATLAB jobs |
+| [Python](./python)                      | The Python directory includes examples bash scripts and Python functions for [serial](./python/serial) Python job, with multithreaded and GPU examples coming soon |
+
+## Additional Information
+
+For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
+
+- [Slurm README](../README.md)
+- [Placeholder Guide](../README.md#placeholders)
+- [slurm-options.sh](../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/README.md
+++ b/slurm/2_ApplicationSpecific/README.md
@@ -15,8 +15,6 @@ This directory contains batch scripts for a variety of applications that have sp
 
 ## Additional Information
 
-For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
-
-- [Slurm README](../README.md)
-- [Placeholder Guide](../README.md#placeholders)
-- [slurm-options.sh](../slurm-options.sh)
+- The [Slurm README](../README.md) provides details on general Slurm usage.                                
+- The [Placeholders](../README.md#placeholders) section lists the available options for each placeholder used in the example scripts.
+- The [slurm-options.sh](../slurm-options.sh) file outlines commonly used `#SBATCH` directives with their descriptions.

--- a/slurm/2_ApplicationSpecific/README.md
+++ b/slurm/2_ApplicationSpecific/README.md
@@ -2,17 +2,15 @@
 
 ## Using these examples
 
-This directory contains batch scripts for a variety of applications that have special setup requirements.  You will not find an example script for every piece of software installed on CCR's systems.  These examples should be used as guidance and are not set in stone.  Please start with these examples, test for your own use case, and scale as required.  
+This directory contains batch scripts for a variety of applications that have special setup requirements.  You will not find an example script for every piece of software installed on CCR's systems.  These examples should be used as guidance and are not set in stone.  Please start with these examples, test for your own use case, and scale as required.
 
 For additional SLURM directives, refer to [slurm-options.sh](../slurm-options.sh) 
 
-## Placeholders:
+## Table of Topics
 
-Portions of the example batch scripts which must be changed for the script to function are referred to as placeholders and denoted by square brackets. Replace the following placeholders in your script with details specific to your use case before submitting your job.
-
-- `[cluster]`: ub-hpc, faculty
-- `[partition]`: general-compute, debug, industry, scavenger, ub-laser, [other available options](https://docs.ccr.buffalo.edu/en/latest/hpc/clusters/#ub-hpc-compute-cluster)
-- `[qos]`: usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos)
-- `[SlurmAccountName]`: Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to.
-
-
+| Topic                                | Description |
+|--------------------------------------|------------------------|
+| [AlphaFold](./2_ApplicationSpecific/alphafold)                | AlphaFold example |
+| [LSDYNA](./2_ApplicationSpecific/lsdyna)                      | LSDYNA example |
+| [MATLAB](./2_ApplicationSpecific/matlab)                      | The MATLAB directory includes example scripts for running [serial](./2_ApplicationSpecific/matlab/serial), [multithreaded](./2_ApplicationSpecific/matlab/multithreaded), and [GPU](./2_ApplicationSpecific/matlab/GPU) MATLAB jobs |
+| [Python](./2_ApplicationSpecific/python)                      | A directory containing examples of [serial](./2_ApplicationSpecific/python/serial) Python job, with multithreaded and GPU examples coming soon |

--- a/slurm/2_ApplicationSpecific/alphafold/README.md
+++ b/slurm/2_ApplicationSpecific/alphafold/README.md
@@ -1,7 +1,6 @@
 # Example AlphaFold job
 
-Provided is an example AlphaFold slurm job. [T11050.fasta](./T1050.fasta) is a protein sequence provided 
-for...(need info here).
+Provided is an example AlphaFold slurm job and [T11050.fasta](./T1050.fasta) is a protein sequence.
 
 A couple notes on running AlphaFold:
 
@@ -13,11 +12,3 @@ echo $ALPHAFOLD_DATA_DIR
 ```
 - Many of the examples you'll find online run AlphaFold in docker. You do not want to do this. Instead just substitute python3 docker/run_docker.py with the script provided by the alphfold module 
 run_alphafold.py. They will have the same CLI arguments.
-
-## Additional Information
-
-For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
-
-- [Slurm README](../../README.md)
-- [Placeholder Guide](../../README.md#placeholders)
-- [slurm-options.sh](../../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/alphafold/README.md
+++ b/slurm/2_ApplicationSpecific/alphafold/README.md
@@ -14,7 +14,10 @@ echo $ALPHAFOLD_DATA_DIR
 - Many of the examples you'll find online run AlphaFold in docker. You do not want to do this. Instead just substitute python3 docker/run_docker.py with the script provided by the alphfold module 
 run_alphafold.py. They will have the same CLI arguments.
 
-## Placeholders:
+## Additional Information
 
-Portions of this example batch script contain placeholders, denoted by square brackets. Refer to the 2_ApplicationSpecific 
-[README](../README.md) for details and options.
+For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
+
+- [Slurm README](../../README.md)
+- [Placeholder Guide](../../README.md#placeholders)
+- [slurm-options.sh](../../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/alphafold/alpha-fold-test.sh
+++ b/slurm/2_ApplicationSpecific/alphafold/alpha-fold-test.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/2_ApplicationSpecific/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 ##   GPU DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/software/modules/#alphafold
 

--- a/slurm/2_ApplicationSpecific/lsdyna/README.md
+++ b/slurm/2_ApplicationSpecific/lsdyna/README.md
@@ -17,7 +17,7 @@ The lsdyna executables do not show up in the path any longer. To use them proper
 
 Provided in this repo are two example lsdyna slurm jobs: [lsdyna.sh](./lsdyna_single_node_smp.sh) a script for running shared memory parallel (SMP) LS-DYNA, [lsdyna_single_node_mpp.sh](./lsdyna_single_node_smp.sh) and [lsdyna_multi_node_mpp.sh](./lsdyna_multi_node_mpp.sh) scripts with examples for message passing parallel (MPP) LS-DYNA.  We provide examples of single and double precision for both options.  Please uncomment the line with the command you want to use and add a `#` to the beginning of the line with the command you don't want to use.  SMP should be run on a single node.  MPP can run on multiple cores of a single node or potentially across multiple nodes.  You can find an example input file `ball_and_plate.k` for testing purposes on CCR's systems in `/util/software/examples/lsdyna`.  These scripts may need to be modified to properly work for your problem.  Please refer to the Ansys LS-DYNA [manuals](https://lsdyna.ansys.com/manuals/) for further information and options.
 
-## Memory Specification:  
+## Memory Specification:
 
 The LS-DYNA command line option MEMORY specifies memory per node with a base unit words. This is not the same thing as requesting memory (or RAM) for your job.  The argument can be specified in words or megawords (denoted by m). For single precision LS-DYNA, a word is 4 bytes and a megaword is 4 MB. For double precision, a word is 8 bytes and a megaword is 8MB.
 
@@ -36,11 +36,3 @@ MEMORY=600      #600 words = 600 words * 8 B = 4800 KB
 ```
 
 Thanks to [Texas A&M](https://hprc.tamu.edu/kb/Software/LST/ls-dyna/) for their excellent documentation.
-
-## Additional Information
-
-For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
-
-- [Slurm README](../../README.md)
-- [Placeholder Guide](../../README.md#placeholders)
-- [slurm-options.sh](../../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/lsdyna/README.md
+++ b/slurm/2_ApplicationSpecific/lsdyna/README.md
@@ -15,13 +15,7 @@ The lsdyna executables do not show up in the path any longer. To use them proper
 
 ## Example Scripts:  
 
-Provided in this repo are two example lsdyna slurm jobs: [lsdyna.sh](./lsdyna_single_node_smp.sh) a script for running shared memory parallel (SMP) LS-DYNA, [lsdyna_single_node_mpp.sh](./lsdyna_single_node_smp.sh) and [lsdyna_multi_node_mpp.sh](./lsdyna_multi_node_mpp.sh) scripts with examples for message passing parallel (MPP) LS-DYNA.  We provide examples of single and double precision for both options.  Please uncomment the line with the command you want to use and add a `#` to the beginning of the line with the command you don't want to use.  SMP should be run on a single node.  MPP can run on multiple cores of a single node or potentially across multiple nodes.  You can find an example input file `ball_and_plate.k` for testing purposes on CCR's systems in `/util/software/examples/lsdyna`.  These scripts may need to be modified to properly work for your problem.  Please refer to the Ansys LS-DYNA [manuals](https://lsdyna.ansys.com/manuals/) for further information and options.  
-
-## Placeholders:
-
-Portions of this example batch script contain placeholders, denoted by square brackets. Refer to the 2_ApplicationSpecific 
-[README](../README.md) for details and options.
-
+Provided in this repo are two example lsdyna slurm jobs: [lsdyna.sh](./lsdyna_single_node_smp.sh) a script for running shared memory parallel (SMP) LS-DYNA, [lsdyna_single_node_mpp.sh](./lsdyna_single_node_smp.sh) and [lsdyna_multi_node_mpp.sh](./lsdyna_multi_node_mpp.sh) scripts with examples for message passing parallel (MPP) LS-DYNA.  We provide examples of single and double precision for both options.  Please uncomment the line with the command you want to use and add a `#` to the beginning of the line with the command you don't want to use.  SMP should be run on a single node.  MPP can run on multiple cores of a single node or potentially across multiple nodes.  You can find an example input file `ball_and_plate.k` for testing purposes on CCR's systems in `/util/software/examples/lsdyna`.  These scripts may need to be modified to properly work for your problem.  Please refer to the Ansys LS-DYNA [manuals](https://lsdyna.ansys.com/manuals/) for further information and options.
 
 ## Memory Specification:  
 
@@ -42,3 +36,11 @@ MEMORY=600      #600 words = 600 words * 8 B = 4800 KB
 ```
 
 Thanks to [Texas A&M](https://hprc.tamu.edu/kb/Software/LST/ls-dyna/) for their excellent documentation.
+
+## Additional Information
+
+For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
+
+- [Slurm README](../../README.md)
+- [Placeholder Guide](../../README.md#placeholders)
+- [slurm-options.sh](../../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/lsdyna/lsdyna_multi_node_mpp.sh
+++ b/slurm/2_ApplicationSpecific/lsdyna/lsdyna_multi_node_mpp.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/2_Applications/matlab/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/2_ApplicationSpecific/lsdyna/lsdyna_single_node_mpp.sh
+++ b/slurm/2_ApplicationSpecific/lsdyna/lsdyna_single_node_mpp.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/2_Applications/matlab/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/2_ApplicationSpecific/lsdyna/lsdyna_single_node_smp.sh
+++ b/slurm/2_ApplicationSpecific/lsdyna/lsdyna_single_node_smp.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/2_Applications/matlab/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/2_ApplicationSpecific/matlab/GPU/matlab-gpu.sh
+++ b/slurm/2_ApplicationSpecific/matlab/GPU/matlab-gpu.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README-https://github.com/ubccr/ccr-examples/tree/main/slurm/2_Applications/matlab/README.md
+##   README-https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/2_ApplicationSpecific/matlab/README.md
+++ b/slurm/2_ApplicationSpecific/matlab/README.md
@@ -2,14 +2,6 @@
 
 This directory includes examples of serial, multithreaded, and GPU  MATLAB jobs.
 
-## Helpful Information
-
-For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
-
-- [Slurm README](../../README.md)
-- [Placeholder Guide](../../README.md#placeholders)
-- [slurm-options.sh](../../slurm-options.sh)
-
 ## Serial MATLAB job ([serial/](./serial))
 
 A serial MATLAB job is one that requires only a single CPU-core.

--- a/slurm/2_ApplicationSpecific/matlab/README.md
+++ b/slurm/2_ApplicationSpecific/matlab/README.md
@@ -1,11 +1,14 @@
 # MATLAB on the CCR Clusters
 
-This directory includes examples of serial, multithreaded, and GPU  MATLAB jobs. (CCR Staff: Need more info here)
+This directory includes examples of serial, multithreaded, and GPU  MATLAB jobs.
 
-## Placeholders:
+## Helpful Information
 
-Portions of the example batch scripts contain placeholders, denoted by square brackets. Refer to the 2_ApplicationSpecific 
-[README](../README.md) for details and options.
+For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
+
+- [Slurm README](../../README.md)
+- [Placeholder Guide](../../README.md#placeholders)
+- [slurm-options.sh](../../slurm-options.sh)
 
 ## Serial MATLAB job ([serial/](./serial))
 

--- a/slurm/2_ApplicationSpecific/matlab/multithreaded/matlab-mp.sh
+++ b/slurm/2_ApplicationSpecific/matlab/multithreaded/matlab-mp.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/2_Applications/matlab/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/2_ApplicationSpecific/matlab/serial/matlab-sp.sh
+++ b/slurm/2_ApplicationSpecific/matlab/serial/matlab-sp.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/2_Applications/matlab/README.md
+##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/2_ApplicationSpecific/python/README.md
+++ b/slurm/2_ApplicationSpecific/python/README.md
@@ -12,11 +12,3 @@ To run the Python script, simply submit the job to the scheduler from a login no
 ```
 $ sbatch python-sp.sh
 ```
-
-## Additional Information
-
-For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
-
-- [Slurm README](../../README.md)
-- [Placeholder Guide](../../README.md#placeholders)
-- [slurm-options.sh](../../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/python/README.md
+++ b/slurm/2_ApplicationSpecific/python/README.md
@@ -2,10 +2,6 @@
 
 This directory includes examples of a serial Python job, with mutlithreaded and GPU examples coming soon.
 
-## Placeholders:
-
-Portions of the example batch script contain placeholders, denoted by square brackets. Refer to the 2_ApplicationSpecific [README](../README.md) for details and options.
-
 ## Serial Python job ([serial/](./serial))
 
 A serial Python job is one that requires only a single CPU-core.
@@ -17,3 +13,10 @@ To run the Python script, simply submit the job to the scheduler from a login no
 $ sbatch python-sp.sh
 ```
 
+## Additional Information
+
+For more details on placeholder values, Slurm usage and common directives, refer to the following resources:
+
+- [Slurm README](../../README.md)
+- [Placeholder Guide](../../README.md#placeholders)
+- [slurm-options.sh](../../slurm-options.sh)

--- a/slurm/2_ApplicationSpecific/python/serial/python-sp.sh
+++ b/slurm/2_ApplicationSpecific/python/serial/python-sp.sh
@@ -2,7 +2,7 @@
 
 ##   This file is intended to serve as a template to be downloaded and modified for your use case.
 ##   For more information, refer to the following resources whenever referenced in the script-
-##   README- https://github.com/ubccr/ccr-examples/blob/main/slurm/2_ApplicationSpecific/python/README.md
+##   README- https://github.com/ubccr/ccr-examples/blob/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -1,18 +1,39 @@
 # Example Slurm scripts
 
-These are examples of how to setup a slurm job on CCR's clusters. Refer to our documentation on [running and monitoring jobs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/) for detailed information.  These examples supplement the documentation.  It's important to understand the concepts of batch computing and CCR's specific cluster use and limits prior to using these examples.
+This directory contains example Slurm job scripts for use on CCR's clusters. These examples are meant to supplement our official documentation on [running and monitoring jobs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/). Before using these scripts, it's important to understand the basics of batch computing as well as CCR-specific usage guidelines and limitations. Please refer to the full documentation for detailed instructions and best practices.
 
-## How to use
+At CCR you should use the bash shell for your Slurm scripts; indicated by the first line in each example (`#!/bin/bash`). In bash scripts, lines beginning with `#` are treated as comments and ignored during execution. However, Slurm specifically looks for lines that start with `#SBATCH`, and these are interpreted as job directives.
+**Important**: Do not remove the `#` in front of `SBATCH`; doing so will prevent Slurm from recognizing your job options. If you want to disable a specific directive without removing it, simply comment it out by adding an extra `#` (i.e., `##SBATCH`).
 
-The [slurm-options.sh](slurm-options.sh) file in this directory provides a list of the most commonly used Slurm directives and a short explanation for each one.  It is not necessary to use all of these directives in every job script.  In the sample scripts throughout this repository, we list the required Slurm directives and a few others just as examples.  Refer to the [slurm-options.sh](slurm-options.sh) file for a more complete list of directives and also to our [documentation](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) for specific cluster and partition limits.  Know that the more specific you get when requesting resources on CCR's clusters, the fewer options the job scheduler has to place your job.  When possible, it's best to only specify what you need to and let the scheduler do it's job.  If you're unsure what resources your program will require, we recommend starting small and [monitoring the progress](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#monitoring-jobs) of the job, then you can scale up.
+- The [slurm-options.sh](slurm-options.sh) file in this directory provides a list of the most commonly used Slurm directives and a short explanation for each one.  It is not necessary to use all of these directives in every job script.  In the sample scripts throughout this repository, we list the required Slurm directives and a few others just as examples.  Know that the more specific you get when requesting resources on CCR's clusters, the fewer options the job scheduler has to place your job.  When possible, it's best to only specify what you need to and let the scheduler do it's job.  If you're unsure what resources your program will require, we recommend starting small and [monitoring the progress](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#monitoring-jobs) of the job, then you can scale up.
 
-At CCR you should use the bash shell for your Slurm scripts; you'll see this on the first line of every example we share.  In a bash script, anything after the `#` is considered a comment and is not interpretted when the script is run.  In the case of Slurm scripts though, the Slurm scheduler is specifically looking for lines that start with `#SBATCH` and will interpret those as requests for your job.  Do NOT remove the `#` in front of the `SBATCH` command or your batch script will not work properly.  If you don't want Slurm to look at a particular `SBATCH` line in your script, put two `#` in front of the line.  
+## Placeholders
 
-## Navigating these directories  
+Portions of the example batch scripts which must be changed for the script to function are referred to as placeholders and denoted by square brackets. Replace the following placeholders in your script with details specific to your use case before submitting your job.
 
-- [0_Introductory](0_Introductory/README.md) - contains beginner batch scripts for the ub-hpc and faculty clusters  
-- 1_Advanced (coming soon) - contains batch scripts for more complicated use cases such as job arrays, parallel computing, and using the scavenger partition  
-- [2_ApplicationSpecific](2_ApplicationSpecific/README.md) - contains batch scripts for a variety of applications that have special setup requirements.  You will not find an example script for every piece of software installed on CCR's systems  
+| Placeholder             | Options |
+|-------------------------|-------------------------------------------|
+| `[cluster]`             | ub-hpc, faculty |
+| `[partition]`           | general-compute, debug, industry, scavenger, ub-laser, [other available options](https://docs.ccr.buffalo.edu/en/latest/hpc/clusters/#ub-hpc-compute-cluster) |
+| `[qos]`                 | usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) |
+| `[SlurmAccountName]`    | Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to |
 
+## Getting Started ([0_Introductory/](./0_Introductory/README.md))
+
+This directory is designed to introduce new users to the fundamentals of submitting jobs on CCR's HPC clusters using Slurm. It provides simple, well-documented examples to help users understand key Slurm concepts and serves as a foundation before progressing to more advanced workflows.
+
+The example Slurm script [0_Introductory/BasicExample.sh](./0_Introductory/BasicExample.sh) provides a simple template for submitting a basic job in an HPC environment. It demonstrates essential Slurm directives, such as cluster, partition, memory requirements, and more.
+
+For additional Slurm directives, refer to [slurm-options.sh](./slurm-options.sh)
+
+## Advanced Slurm Examples ([1_Advanced/](./1_Advanced/README.md))
+
+This directory includes Slurm scripts for more complex use cases such as job arrays, parallel computing, and using the scavenger partition.
+
+## Application Specific Scripts ([2_ApplicationSpecific/](./ApplicationSpecific/README.md))
+
+This directory contains Slurm job scripts tailored for specific applications that have specific setup requirements like Alphafold, MATLAB, Python, etc. Note that not every piece of software installed on CCR's systems has an example script in this directory.
+
+A [table](./ApplicationSpecific/README.md#table-of-topics) of available scripts for  applications is provided for easier navigation and reference.
 
 

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -2,10 +2,10 @@
 
 This directory contains example Slurm job scripts for use on CCR's clusters. These examples are meant to supplement our official documentation on [running and monitoring jobs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/). Before using these scripts, it's important to understand the basics of batch computing as well as CCR-specific usage guidelines and limitations. Please refer to the full documentation for detailed instructions and best practices.
 
-At CCR you should use the bash shell for your Slurm scripts; indicated by the first line in each example (`#!/bin/bash`). In bash scripts, lines beginning with `#` are treated as comments and ignored during execution. However, Slurm specifically looks for lines that start with `#SBATCH`, and these are interpreted as job directives.
-**Important**: Do not remove the `#` in front of `SBATCH`; doing so will prevent Slurm from recognizing your job options. If you want to disable a specific directive without removing it, simply comment it out by adding an extra `#` (i.e., `##SBATCH`).
+At CCR you should use the bash shell for your Slurm scripts; indicated by the first line in each example (`#!/bin/bash -l`). Slurm batch script files typically have a `.sh` extension. In bash scripts, lines beginning with `#` are treated as comments and ignored during execution. However, Slurm specifically looks for lines that start with `#SBATCH`, and these are interpreted as job directives.
+**Important**: Do not remove the `#` in front of `SBATCH`; doing so will prevent Slurm from recognizing your job options. The best practice for adding your own comments is to place them on their own lines and use `##` to ensure that Slurm does not confuse them with directives. If you want to disable a specific directive without removing it, simply comment it out by adding an extra `#` (i.e.,`##SBATCH`).
 
-The [slurm-options.sh](slurm-options.sh) file in this directory provides a list of the most commonly used Slurm directives and a short explanation for each one.  It is not necessary to use all of these directives in every job script.  In the sample scripts throughout this repository, we list the required Slurm directives and a few others just as examples.  Know that the more specific you get when requesting resources on CCR's clusters, the fewer options the job scheduler has to place your job.  When possible, it's best to only specify what you need to and let the scheduler do it's job.  If you're unsure what resources your program will require, we recommend starting small and [monitoring the progress](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#monitoring-jobs) of the job, then you can scale up.
+The [slurm-options.sh](slurm-options.sh) file in this directory provides a list of the most commonly used Slurm directives and a short explanation for each one.  It is not necessary to use all of these directives in every job script.  In the sample scripts throughout this repository, we list the required Slurm directives and a few others just as examples.  Know that the more specific you get when requesting resources on CCR's clusters, the fewer options the job scheduler has to place your job.  When possible, it's best to only specify what you need to and let the scheduler do it's job.  If you're unsure what resources your program will require, we recommend starting small and [monitoring the progress](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#monitoring-jobs) of the job, then you can scale up. For more details, refer to the [official Slurm documentation](https://slurm.schedmd.com/documentation.html).
 
 ## Placeholders
 
@@ -18,22 +18,16 @@ Portions of the example batch scripts which must be changed for the script to fu
 | `[qos]`                 | usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) |
 | `[SlurmAccountName]`    | Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to |
 
-## - Getting Started ([0_Introductory/](./0_Introductory/README.md))
+## Getting Started ([0_Introductory/](./0_Introductory/README.md))
 
-This directory is designed to introduce new users to the fundamentals of submitting jobs on CCR's HPC clusters using Slurm. It provides simple, well-documented examples to help users understand key Slurm concepts and serves as a foundation before progressing to more advanced workflows.
+This directory is designed to introduce new users to the fundamentals of submitting jobs on CCR's HPC clusters using Slurm. It provides simple, well-documented examples to help users understand key Slurm concepts and serves as a foundation before progressing to more advanced workflows. The example Slurm script [BasicExample.sh](./0_Introductory/BasicExample.sh) provides a minimalist template for submitting a job in an HPC environment. It demonstrates essential Slurm directives, such as cluster, partition, memory requirements, and more.
 
-The example Slurm script [0_Introductory/BasicExample.sh](./0_Introductory/BasicExample.sh) provides a simple template for submitting a basic job in an HPC environment. It demonstrates essential Slurm directives, such as cluster, partition, memory requirements, and more.
-
-For additional Slurm directives, refer to [slurm-options.sh](./slurm-options.sh)
-
-## - Advanced Slurm Examples ([1_Advanced/](./1_Advanced/README.md))
+## Advanced Slurm Examples ([1_Advanced/](./1_Advanced/README.md))
 
 This directory includes Slurm scripts for more complex use cases such as job arrays, parallel computing, and using the scavenger partition.
 
-## - Application Specific Scripts ([2_ApplicationSpecific/](./2_ApplicationSpecific/README.md))
+## Application Specific Scripts ([2_ApplicationSpecific/](./2_ApplicationSpecific/README.md))
 
-This directory contains Slurm job scripts tailored for specific applications that have specific setup requirements like Alphafold, MATLAB, Python, etc. Note that not every piece of software installed on CCR's systems has an example script in this directory.
-
-A [table](./2_ApplicationSpecific/README.md#table-of-topics) of available scripts for  applications is provided for easier navigation and reference.
+This directory contains Slurm job scripts tailored for specific applications that have specific setup requirements like Alphafold, MATLAB, Python, etc. Note that not every piece of software installed on CCR's systems has an example script in this directory. A [table](./2_ApplicationSpecific/README.md#table-of-topics) of available scripts for  applications is provided for easier navigation and reference.
 
 

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -30,10 +30,10 @@ For additional Slurm directives, refer to [slurm-options.sh](./slurm-options.sh)
 
 This directory includes Slurm scripts for more complex use cases such as job arrays, parallel computing, and using the scavenger partition.
 
-## - Application Specific Scripts ([2_ApplicationSpecific/](./ApplicationSpecific/README.md))
+## - Application Specific Scripts ([2_ApplicationSpecific/](./2_ApplicationSpecific/README.md))
 
 This directory contains Slurm job scripts tailored for specific applications that have specific setup requirements like Alphafold, MATLAB, Python, etc. Note that not every piece of software installed on CCR's systems has an example script in this directory.
 
-A [table](./ApplicationSpecific/README.md#table-of-topics) of available scripts for  applications is provided for easier navigation and reference.
+A [table](./2_ApplicationSpecific/README.md#table-of-topics) of available scripts for  applications is provided for easier navigation and reference.
 
 

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -5,7 +5,7 @@ This directory contains example Slurm job scripts for use on CCR's clusters. The
 At CCR you should use the bash shell for your Slurm scripts; indicated by the first line in each example (`#!/bin/bash`). In bash scripts, lines beginning with `#` are treated as comments and ignored during execution. However, Slurm specifically looks for lines that start with `#SBATCH`, and these are interpreted as job directives.
 **Important**: Do not remove the `#` in front of `SBATCH`; doing so will prevent Slurm from recognizing your job options. If you want to disable a specific directive without removing it, simply comment it out by adding an extra `#` (i.e., `##SBATCH`).
 
-- The [slurm-options.sh](slurm-options.sh) file in this directory provides a list of the most commonly used Slurm directives and a short explanation for each one.  It is not necessary to use all of these directives in every job script.  In the sample scripts throughout this repository, we list the required Slurm directives and a few others just as examples.  Know that the more specific you get when requesting resources on CCR's clusters, the fewer options the job scheduler has to place your job.  When possible, it's best to only specify what you need to and let the scheduler do it's job.  If you're unsure what resources your program will require, we recommend starting small and [monitoring the progress](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#monitoring-jobs) of the job, then you can scale up.
+The [slurm-options.sh](slurm-options.sh) file in this directory provides a list of the most commonly used Slurm directives and a short explanation for each one.  It is not necessary to use all of these directives in every job script.  In the sample scripts throughout this repository, we list the required Slurm directives and a few others just as examples.  Know that the more specific you get when requesting resources on CCR's clusters, the fewer options the job scheduler has to place your job.  When possible, it's best to only specify what you need to and let the scheduler do it's job.  If you're unsure what resources your program will require, we recommend starting small and [monitoring the progress](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#monitoring-jobs) of the job, then you can scale up.
 
 ## Placeholders
 
@@ -18,7 +18,7 @@ Portions of the example batch scripts which must be changed for the script to fu
 | `[qos]`                 | usually the same as `[partition]` - refer to [CCR docs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) |
 | `[SlurmAccountName]`    | Tell Slurm which account to run this job under. If not specified, your default account will be used. Use the `slimits` command to see what accounts you have access to |
 
-## Getting Started ([0_Introductory/](./0_Introductory/README.md))
+## - Getting Started ([0_Introductory/](./0_Introductory/README.md))
 
 This directory is designed to introduce new users to the fundamentals of submitting jobs on CCR's HPC clusters using Slurm. It provides simple, well-documented examples to help users understand key Slurm concepts and serves as a foundation before progressing to more advanced workflows.
 
@@ -26,11 +26,11 @@ The example Slurm script [0_Introductory/BasicExample.sh](./0_Introductory/Basic
 
 For additional Slurm directives, refer to [slurm-options.sh](./slurm-options.sh)
 
-## Advanced Slurm Examples ([1_Advanced/](./1_Advanced/README.md))
+## - Advanced Slurm Examples ([1_Advanced/](./1_Advanced/README.md))
 
 This directory includes Slurm scripts for more complex use cases such as job arrays, parallel computing, and using the scavenger partition.
 
-## Application Specific Scripts ([2_ApplicationSpecific/](./ApplicationSpecific/README.md))
+## - Application Specific Scripts ([2_ApplicationSpecific/](./ApplicationSpecific/README.md))
 
 This directory contains Slurm job scripts tailored for specific applications that have specific setup requirements like Alphafold, MATLAB, Python, etc. Note that not every piece of software installed on CCR's systems has an example script in this directory.
 


### PR DESCRIPTION
- Updated `/slurm/README.md` with placeholder info and an overview of the directory
- Modified all Slurm bash scripts to point to the slurm README for placeholder guidance
- Added a table of topics to `2_ApplicationSpecific/README.md` for easier navigation
- Added “Additional Information” sections to `/slurm/*/README.md` files, with plans for future expansion