### PR TITLE
Add Abaqus and SAS Examples with Slurm Scripts; Update 2_ApplicationSpecific README

### DIFF
--- a/containers/2_ApplicationSpecific/README.md
+++ b/containers/2_ApplicationSpecific/README.md
@@ -1,7 +1,22 @@
 # Application Specific Container Examples
 
- TODO: write me
-
 ## How to use
 
-TODO: write me
+This directory contains examples for building and running specific containers with Apptainer, including applications that require specialized container setups. You will not find an example for every piece of software installed on CCR's systems. These examples should be used as guidance and are not set in stone. Please start with these examples, test for your own use case, and scale as required. 
+
+Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for information on building and using Apptainer.
+
+## Table of Topics
+
+| Topic                                | Description |
+|--------------------------------------|------------------------|
+| [CONDA](./conda)                     | Example CONDA container with steps for building and running via Apptainer |
+| [VASP](./vasp)                       | Example VASP container with steps for building and running via Apptainer |
+| [Abaqus](./abaqus)                   | Guide to running Abaqus with Apptainer via Slurm batch script, command line, GUI access, and GPU support |
+| [SAS](./sas)                         | Guide for running SAS using Apptainer via Slurm batch script, command line, and GUI access |
+
+## Additional Information
+
+- The [Slurm README](../../slurm/README.md) provides details on general Slurm usage.
+- The [Placeholders](../../slurm/README.md#placeholders) section lists the available options for each placeholder used in the example scripts.
+- The [slurm-options.sh](../../slurm/slurm-options.sh) file outlines commonly used `#SBATCH` directives with their descriptions.

--- a/containers/2_ApplicationSpecific/README.md
+++ b/containers/2_ApplicationSpecific/README.md
@@ -2,7 +2,7 @@
 
 ## How to use
 
-This directory contains examples for building and running specific containers with Apptainer, including applications that require specialized container setups. You will not find an example for every piece of software installed on CCR's systems. These examples should be used as guidance and are not set in stone. Please start with these examples, test for your own use case, and scale as required. 
+This directory contains examples for building and running specific containers with Apptainer, including applications that require specialized container setups. You will not find an example for every software application. These container examples should be used as guidance and can be modified for your own use case.
 
 Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for information on building and using Apptainer.
 

--- a/containers/2_ApplicationSpecific/abaqus/README.md
+++ b/containers/2_ApplicationSpecific/abaqus/README.md
@@ -1,6 +1,6 @@
 # Running Abaqus with Apptainer
 
-Abaqus 2024 is available via an Apptainer/Singularity container. You can find the Abaqus container here: `/util/software/containers/x86_64/abaqus-2024.sif`
+Abaqus 2024 is available via an Apptainer/Singularity container. The Abaqus container file can be found in this directory: `/util/software/containers/x86_64/abaqus-2024.sif` which is accessible when logged into CCR's HPC environment.
 This is a large file (10GB) so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
 
 **Note**: Apptainer/Singularity is only available on compute and compile nodes. Please refer to our [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information on using containers.
@@ -11,7 +11,7 @@ To run Abaqus from the command line, run this command: `$ apptainer exec -B /uti
 
 **Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
 
-A Slurm script [`abaqus-test.sh`](./abaqus-test.sh) is provided with all necessary configuration for running Abaqus in a batch script. Update the file paths and resource requests according to your needs. Once the container starts you'll see the Apptainer command prompt and then you can run the Abaqus command as normal. For example: `Apptainer> abaqus help`
+A Slurm script [`abaqus-test.sh`](./abaqus-test.sh) is provided with all necessary configuration for running Abaqus as a batch job. Update the file paths and resource requests according to your needs and add the Abaqus options you need to use at the end of the Apptainer command line.
 
 ## Abaqus GUI
 
@@ -19,10 +19,10 @@ To run the Abaqus GUI using this container, first start an [OnDemand desktop](ht
 
 ## Abaqus and GPUs
 
-If you need to use GPUs with Abaqus you'll need to request a GPU node and add a few things to the Apptainer/Singularity command that starts the container. Add this after the rest of your bind mounts in the Apptainer/Singularity exec command: `,/opt/software/nvidia:/opt/software/nvidia --nv`
+If you need to use GPUs with Abaqus you'll need to request a [GPU node](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) and add a few things to the Apptainer/Singularity command that starts the container. Add this after the rest of your bind mounts in the Apptainer/Singularity command: `,/opt/software/nvidia:/opt/software/nvidia --nv`
 
 To run the Abaqus GUI on a GPU node, the command would be: `$ apptainer exec -B /util:/util,/scratch:/scratch,/opt/software/nvidia:/opt/software/nvidia --nv /util/software/containers/x86_64/abaqus-2024.sif abaqus cae -mesa`
 
 **NOTE**: If you're using the Abaqus GUI, we recommend running on the viz partition and qos of the UB-HPC cluster. However, this will work from any GPU node.
 
-Please refer to the [Abaqus (Simulia) documentation](https://help.3ds.com/2020/English/DSSIMULIA_Established/SIMULIA_Established_FrontmatterMap/sim-t-SIMULIA_EstablishedDocSearchOnline.html) for additional information and support on using this software.
+Please refer to the [Abaqus (Simulia) documentation](https://docs.software.vt.edu/abaqusv2024/English/?show=SIMULIA_Established_FrontmatterMap/sim-r-DSDocAbaqus.htm) for additional information and support on using this software.

--- a/containers/2_ApplicationSpecific/abaqus/README.md
+++ b/containers/2_ApplicationSpecific/abaqus/README.md
@@ -7,21 +7,41 @@ This is a large file (10GB) so please be sure to copy it to a location where you
 
 ## Abaqus Command Line/Batch Script
 
-To run Abaqus from the command line, run this command: `$ apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif /bin/bash`
+There are several options to run Abaqus from the command line. If you're unsure of the options to provide or want to run the application more interactively, use the `shell` option with Apptainer. This will drop you into the container and then you can work with Abaqus interactively. For example:
+```
+apptainer shell -B /util:/util,/scratch:/scratch /[path-to-container]/abaqus-2024.sif /bin/bash
+Apptainer> abaqus help
+```
 
-**Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
+If you know what options you need to run Abaqus, use the `exec` option with Apptainer and specify them all in the apptainer command. For example:
+```
+apptainer exec -B /util:/util,/scratch:/scratch /[path-to-container]/abaqus-2024.sif abaqus [options]
+```
+
+See the [Abaqus documentation](https://docs.software.vt.edu/abaqusv2024/English/?show=SIMACAEEXCRefMap/simaexc-c-analysisproc.htm) for the full list of command line options.
+
+**Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example. This would update the previous example command to this:
+```
+apptainer exec -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName] /[path-to-container]/abaqus-2024.sif abaqus [options]
+```
 
 A Slurm script [`abaqus-test.sh`](./abaqus-test.sh) is provided with all necessary configuration for running Abaqus as a batch job. Update the file paths and resource requests according to your needs and add the Abaqus options you need to use at the end of the Apptainer command line.
 
 ## Abaqus GUI
 
-To run the Abaqus GUI using this container, first start an [OnDemand desktop](https://docs.ccr.buffalo.edu/en/latest/portals/ood/#interactive-apps) session. Once started, launch a terminal in the OnDemand desktop. Then run this command to start the container and launch the Abaqus GUI: `$ apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif abaqus cae -mesa`
+To run the Abaqus GUI using this container, first start an [OnDemand desktop](https://docs.ccr.buffalo.edu/en/latest/portals/ood/#interactive-apps) session. Once started, launch a terminal in the OnDemand desktop. Then run this command to start the container and launch the Abaqus GUI:
+```
+apptainer exec -B /util:/util,/scratch:/scratch /[path-to-container]/abaqus-2024.sif abaqus cae -mesa
+```
 
 ## Abaqus and GPUs
 
 If you need to use GPUs with Abaqus you'll need to request a [GPU node](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos) and add a few things to the Apptainer/Singularity command that starts the container. Add this after the rest of your bind mounts in the Apptainer/Singularity command: `,/opt/software/nvidia:/opt/software/nvidia --nv`
 
-To run the Abaqus GUI on a GPU node, the command would be: `$ apptainer exec -B /util:/util,/scratch:/scratch,/opt/software/nvidia:/opt/software/nvidia --nv /util/software/containers/x86_64/abaqus-2024.sif abaqus cae -mesa`
+For example, to run the Abaqus GUI on a GPU node, the command would be:
+```
+apptainer exec -B /util:/util,/scratch:/scratch,/opt/software/nvidia:/opt/software/nvidia --nv /[path-to-container]/abaqus-2024.sif abaqus cae -mesa
+```
 
 **NOTE**: If you're using the Abaqus GUI, we recommend running on the viz partition and qos of the UB-HPC cluster. However, this will work from any GPU node.
 

--- a/containers/2_ApplicationSpecific/abaqus/README.md
+++ b/containers/2_ApplicationSpecific/abaqus/README.md
@@ -9,7 +9,7 @@ This is a large file (10GB) so please be sure to copy it to a location where you
 
 There are several options to run Abaqus from the command line. If you're unsure of the options to provide or want to run the application more interactively, use the `shell` option with Apptainer. This will drop you into the container and then you can work with Abaqus interactively. For example:
 ```
-apptainer shell -B /util:/util,/scratch:/scratch /[path-to-container]/abaqus-2024.sif /bin/bash
+apptainer shell -B /util:/util,/scratch:/scratch /[path-to-container]/abaqus-2024.sif
 Apptainer> abaqus help
 ```
 

--- a/containers/2_ApplicationSpecific/abaqus/README.md
+++ b/containers/2_ApplicationSpecific/abaqus/README.md
@@ -1,6 +1,7 @@
 # Running Abaqus with Apptainer
 
-Abaqus 2024 is available via an Apptainer/Singularity container. You can find the Abaqus container here: `/util/software/containers/x86_64/abaqus-2024.sif` This is a large file (10GB) so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
+Abaqus 2024 is available via an Apptainer/Singularity container. You can find the Abaqus container here: `/util/software/containers/x86_64/abaqus-2024.sif`
+This is a large file (10GB) so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
 
 **Note**: Apptainer/Singularity is only available on compute and compile nodes. Please refer to our [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information on using containers.
 
@@ -8,9 +9,9 @@ Abaqus 2024 is available via an Apptainer/Singularity container. You can find th
 
 To run Abaqus from the command line, run this command: `$ apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif /bin/bash`
 
-A Slurm script [`abaqus-test.sh`](./abaqus-test.sh) is provided with all necessary configuration for running Abaqus in a batch script. Update the file paths and resource requests according to your needs. Once the container starts you'll see the Apptainer command prompt and then you can run the Abaqus command as normal. For example: `Apptainer> abaqus help`
-
 **Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
+
+A Slurm script [`abaqus-test.sh`](./abaqus-test.sh) is provided with all necessary configuration for running Abaqus in a batch script. Update the file paths and resource requests according to your needs. Once the container starts you'll see the Apptainer command prompt and then you can run the Abaqus command as normal. For example: `Apptainer> abaqus help`
 
 ## Abaqus GUI
 

--- a/containers/2_ApplicationSpecific/abaqus/README.md
+++ b/containers/2_ApplicationSpecific/abaqus/README.md
@@ -1,0 +1,27 @@
+# Running Abaqus with Apptainer
+
+Abaqus 2024 is available via an Apptainer/Singularity container. You can find the Abaqus container here: `/util/software/containers/x86_64/abaqus-2024.sif` This is a large file (10GB) so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
+
+**Note**: Apptainer/Singularity is only available on compute and compile nodes. Please refer to our [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information on using containers.
+
+## Abaqus Command Line/Batch Script
+
+To run Abaqus from the command line, run this command: `$ apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif /bin/bash`
+
+A Slurm script [`abaqus-test.sh`](./abaqus-test.sh) is provided with all necessary configuration for running Abaqus in a batch script. Update the file paths and resource requests according to your needs. Once the container starts you'll see the Apptainer command prompt and then you can run the Abaqus command as normal. For example: `Apptainer> abaqus help`
+
+**Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
+
+## Abaqus GUI
+
+To run the Abaqus GUI using this container, first start an [OnDemand desktop](https://docs.ccr.buffalo.edu/en/latest/portals/ood/#interactive-apps) session. Once started, launch a terminal in the OnDemand desktop. Then run this command to start the container and launch the Abaqus GUI: `$ apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif abaqus cae -mesa`
+
+## Abaqus and GPUs
+
+If you need to use GPUs with Abaqus you'll need to request a GPU node and add a few things to the Apptainer/Singularity command that starts the container. Add this after the rest of your bind mounts in the Apptainer/Singularity exec command: `,/opt/software/nvidia:/opt/software/nvidia --nv`
+
+To run the Abaqus GUI on a GPU node, the command would be: `$ apptainer exec -B /util:/util,/scratch:/scratch,/opt/software/nvidia:/opt/software/nvidia --nv /util/software/containers/x86_64/abaqus-2024.sif abaqus cae -mesa`
+
+**NOTE**: If you're using the Abaqus GUI, we recommend running on the viz partition and qos of the UB-HPC cluster. However, this will work from any GPU node.
+
+Please refer to the [Abaqus (Simulia) documentation](https://help.3ds.com/2020/English/DSSIMULIA_Established/SIMULIA_Established_FrontmatterMap/sim-t-SIMULIA_EstablishedDocSearchOnline.html) for additional information and support on using this software.

--- a/containers/2_ApplicationSpecific/abaqus/abaqus-test.sh
+++ b/containers/2_ApplicationSpecific/abaqus/abaqus-test.sh
@@ -26,5 +26,6 @@
 ##   Specify real memory required per node. Default units are megabytes
 #SBATCH --mem=10000
 
-##   Run the abaqus job inside the Apptainer container
-apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif /bin/bash
+##   Run abaqus inside the Apptainer container
+## Replace [options] with the abaqus options you want to use
+apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif abaqus [options]

--- a/containers/2_ApplicationSpecific/abaqus/abaqus-test.sh
+++ b/containers/2_ApplicationSpecific/abaqus/abaqus-test.sh
@@ -4,7 +4,6 @@
 ##   For more information, refer to the following resources whenever referenced in the script-
 ##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
-##   GPU DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos (CCR Staff: Needs to be updated)
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case
 ##   Available options and more details are provided in README
@@ -14,7 +13,7 @@
 #SBATCH --account=[SlurmAccountName]
 
 ##   Job runtime limit, the job will be canceled once this limit is reached. Format- dd:hh:mm
-#SBATCH --time=01:30:00
+#SBATCH --time=00:30:00
 
 ##   Refer to DOCUMENTATION for details on the next two directives
 
@@ -22,20 +21,10 @@
 #SBATCH --ntasks=1
 
 ##   Allocate CPUs per task
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=4
 
-##   #Need information here. Refer to GPU DOCUMENTATION
-#SBATCH --gres=gpu:1
+##   Specify real memory required per node. Default units are megabytes
+#SBATCH --mem=10000
 
-module load easybuild
-
-##   Set this to somewhere in your projects directory where you'd like to
-##   build custom modules
-export CCR_BUILD_PREFIX=$SLURMTMPDIR/easybuild
-
-##   This is so that lmod can find your modules. Also can add paths to
-##   ~/.ccr/modulepaths
-export CCR_CUSTOM_BUILD_PATHS="$CCR_BUILD_PREFIX:$CCR_CUSTOM_BUILD_PATHS"
-
-##   Run the build with easybuild
-eb PETSc-3.19.knepley.83c5a5bb-foss-2021b-CUDA-11.8.0.eb
+##   Run the abaqus job inside the Apptainer container
+apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif /bin/bash

--- a/containers/2_ApplicationSpecific/abaqus/abaqus-test.sh
+++ b/containers/2_ApplicationSpecific/abaqus/abaqus-test.sh
@@ -27,5 +27,5 @@
 #SBATCH --mem=10000
 
 ##   Run abaqus inside the Apptainer container
-## Replace [options] with the abaqus options you want to use
+##   Replace [options] with the abaqus options you want to use
 apptainer exec -B /util:/util,/scratch:/scratch /util/software/containers/x86_64/abaqus-2024.sif abaqus [options]

--- a/containers/2_ApplicationSpecific/sas/README.md
+++ b/containers/2_ApplicationSpecific/sas/README.md
@@ -1,6 +1,6 @@
 # Running SAS with Apptainer
 
-SAS 9.4 is available via an Apptainer/Singularity container. You can find the SAS container here: `/util/software/containers/x86_64/sas94.sif` This file is 4GB in size so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
+SAS 9.4 is available via an Apptainer/Singularity container. The SAS container file can be found in this directory: `/util/software/containers/x86_64/sas94.sif` which is accessible when logged into CCR's HPC environment.  This file is 4GB in size so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
 
 **Note**: Apptainer/Singularity is only available on compute and compile nodes. Please refer to our [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information on using containers.
 
@@ -8,11 +8,11 @@ SAS 9.4 is available via an Apptainer/Singularity container. You can find the SA
 
 To run SAS using a SAS script, run this command: `$ apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log` 
 
-Where `~/myjob.sas` is a SAS script in your home directory and `~/sasoutput.log` is a new output file created in your home directory. You can use your project directory for input and output locations as long as you bind mount them in the container as described in the tip below.
+In this example, `~/myjob.sas` is a SAS script in your home directory and `~/sasoutput.log` is a new output file created in your home directory. You can use your project directory for input and output locations as long as you bind mount them in the container as described in the tip below.
 
 **Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
 
-A Slurm script [`sas-test.sh`](./sas-test.sh) is provided with all necessary configuration for running SAS in a batch script. Update the file paths and resource requests according to your needs.
+A Slurm script [`sas-test.sh`](./sas-test.sh) is provided with all necessary configuration for running SAS in a batch script. Update the file paths, resource requests, and SAS options according to your needs.
 
 ## SAS GUI
 

--- a/containers/2_ApplicationSpecific/sas/README.md
+++ b/containers/2_ApplicationSpecific/sas/README.md
@@ -1,0 +1,21 @@
+# Running SAS with Apptainer
+
+SAS 9.4 is available via an Apptainer/Singularity container. You can find the SAS container here: `/util/software/containers/x86_64/sas94.sif` This file is 4GB in size so please be sure to copy it to a location where you have enough space (i.e. your project directory), or you can run the container from this location.
+
+**Note**: Apptainer/Singularity is only available on compute and compile nodes. Please refer to our [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information on using containers.
+
+## SAS Command Line/Batch Script
+
+To run SAS using a SAS script, run this command: `$ apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log` 
+
+Where `~/myjob.sas` is a SAS script in your home directory and `~/sasoutput.log` is a new output file created in your home directory. You can use your project directory for input and output locations as long as you bind mount them in the container as described in the tip below.
+
+**Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
+
+A Slurm script [`sas-test.sh`](./sas-test.sh) is provided with all necessary configuration for running SAS in a batch script. Update the file paths and resource requests according to your needs.
+
+## SAS GUI
+
+To run the SAS GUI using this container, first start an [OnDemand desktop](https://docs.ccr.buffalo.edu/en/latest/portals/ood/#interactive-apps) session. Once started, launch a terminal in the OnDemand desktop. Then run this command to start the container and launch the SAS GUI: `$ apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas`
+
+Please refer to the [SAS documentation](https://support.sas.com/en/documentation.html) for additional information and support on using this software.

--- a/containers/2_ApplicationSpecific/sas/README.md
+++ b/containers/2_ApplicationSpecific/sas/README.md
@@ -6,16 +6,24 @@ SAS 9.4 is available via an Apptainer/Singularity container. The SAS container f
 
 ## SAS Command Line/Batch Script
 
-To run SAS using a SAS script, run this command: `$ apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log` 
-
+To run SAS using a SAS script, run this command:
+```
+apptainer exec -B /scratch:/scratch /[path-to-container]/sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log
+```
 In this example, `~/myjob.sas` is a SAS script in your home directory and `~/sasoutput.log` is a new output file created in your home directory. You can use your project directory for input and output locations as long as you bind mount them in the container as described in the tip below.
 
-**Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example.
+**Tip**: The `-B` option is telling Apptainer/Singularity which directories on the node you want to bind mount into the container. You will automatically get access to your home directory. The directories we have listed here to bind mount are required. If you also want access to your project directory you can add `,/projects:/projects` to the list or your specific directory `,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName]` for example. This would update the previous example command to this:
+```
+apptainer exec -B /scratch:/scratch,/projects/academic/[YourGroupName]:/projects/academic/[YourGroupName] /[path-to-container]/sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log
+```
 
 A Slurm script [`sas-test.sh`](./sas-test.sh) is provided with all necessary configuration for running SAS in a batch script. Update the file paths, resource requests, and SAS options according to your needs.
 
 ## SAS GUI
 
-To run the SAS GUI using this container, first start an [OnDemand desktop](https://docs.ccr.buffalo.edu/en/latest/portals/ood/#interactive-apps) session. Once started, launch a terminal in the OnDemand desktop. Then run this command to start the container and launch the SAS GUI: `$ apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas`
+To run the SAS GUI using this container, first start an [OnDemand desktop](https://docs.ccr.buffalo.edu/en/latest/portals/ood/#interactive-apps) session. Once started, launch a terminal in the OnDemand desktop. Then run this command to start the container and launch the SAS GUI:
+```
+apptainer exec -B /scratch:/scratch /[path-to-container]/sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas
+```
 
 Please refer to the [SAS documentation](https://support.sas.com/en/documentation.html) for additional information and support on using this software.

--- a/containers/2_ApplicationSpecific/sas/sas-test.sh
+++ b/containers/2_ApplicationSpecific/sas/sas-test.sh
@@ -27,4 +27,4 @@
 #SBATCH --mem=10000
 
 ##   Run SAS using a SAS script inside the Apptainer container
-apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log
+apptainer exec -B /scratch:/scratch /[path-to-container]/sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log

--- a/containers/2_ApplicationSpecific/sas/sas-test.sh
+++ b/containers/2_ApplicationSpecific/sas/sas-test.sh
@@ -4,7 +4,6 @@
 ##   For more information, refer to the following resources whenever referenced in the script-
 ##   README- https://github.com/ubccr/ccr-examples/tree/main/slurm/README.md
 ##   DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs
-##   GPU DOCUMENTATION- https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#slurm-directives-partitions-qos (CCR Staff: Needs to be updated)
 
 ##   Select a cluster, partition, qos and account that is appropriate for your use case
 ##   Available options and more details are provided in README
@@ -14,7 +13,7 @@
 #SBATCH --account=[SlurmAccountName]
 
 ##   Job runtime limit, the job will be canceled once this limit is reached. Format- dd:hh:mm
-#SBATCH --time=01:30:00
+#SBATCH --time=00:30:00
 
 ##   Refer to DOCUMENTATION for details on the next two directives
 
@@ -22,20 +21,10 @@
 #SBATCH --ntasks=1
 
 ##   Allocate CPUs per task
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=4
 
-##   #Need information here. Refer to GPU DOCUMENTATION
-#SBATCH --gres=gpu:1
+##   Specify real memory required per node. Default units are megabytes
+#SBATCH --mem=10000
 
-module load easybuild
-
-##   Set this to somewhere in your projects directory where you'd like to
-##   build custom modules
-export CCR_BUILD_PREFIX=$SLURMTMPDIR/easybuild
-
-##   This is so that lmod can find your modules. Also can add paths to
-##   ~/.ccr/modulepaths
-export CCR_CUSTOM_BUILD_PATHS="$CCR_BUILD_PREFIX:$CCR_CUSTOM_BUILD_PATHS"
-
-##   Run the build with easybuild
-eb PETSc-3.19.knepley.83c5a5bb-foss-2021b-CUDA-11.8.0.eb
+##   Run SAS using a SAS script inside the Apptainer container
+apptainer exec -B /scratch:/scratch sas94.sif /usr/local/SASHome/SASFoundation/9.4/sas ~/myjob.sas -log ~/sasoutput.log


### PR DESCRIPTION
Ported Abaqus and SAS examples from our docs and added Slurm scripts for both applications. Updated `containers/2_ApplicationSpecific/README.md` with some info and a table of contents. Minor update to `easybuild/PetSC` Slurm script: changed placeholder reference to slurm/README.md