### PR TITLE
Added multi-platform support to the conda example

### DIFF
--- a/containers/2_ApplicationSpecific/conda/README.md
+++ b/containers/2_ApplicationSpecific/conda/README.md
@@ -35,7 +35,7 @@ CCRusername@cpn-h23-04:~$ export APPTAINER_CACHEDIR=/projects/academic/[YourGrou
 3. Build your container  
 
 ```
-CCRusername@cpn-h23-04:~$ apptainer build conda.sif conda.def
+CCRusername@cpn-h23-04:~$ apptainer build conda-$(arch).sif conda.def
 ...
 ...
 INFO:    Adding environment to container
@@ -50,7 +50,7 @@ NOTE: Whenever you modify the `environment.yml` file to add more Python packages
 For our example, we have no additional conda packages installed.  However, we can test this container by running Python: 
 
 ```
-CCRusername@cpn-h23-04:~$ apptainer exec conda.sif python
+CCRusername@cpn-h23-04:~$ apptainer exec conda-$(arch).sif python
 Python 3.10.16 | packaged by conda-forge | (main, Apr  8 2025, 20:53:32) [GCC 13.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
@@ -59,7 +59,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 Alternatively, you can first get shell access into the container and then run Python, as shown here:   
 
 ```
-CCRusername@cpn-h23-04:~$ apptainer shell conda.sif  
+CCRusername@cpn-h23-04:~$ apptainer shell conda-$(arch).sif
 Apptainer> python
 Python 3.10.16 | packaged by conda-forge | (main, Apr  8 2025, 20:53:32) [GCC 13.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.

--- a/containers/2_ApplicationSpecific/conda/conda.def
+++ b/containers/2_ApplicationSpecific/conda/conda.def
@@ -18,9 +18,9 @@ From: ubuntu:latest
     update-locale LANG=en_US.UTF-8
 
     wget -P /tmp \
-      "https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Miniforge3-Linux-x86_64.sh" \
-      && bash /tmp/Miniforge3-Linux-x86_64.sh -b -p /opt/conda \
-      && rm /tmp/Miniforge3-Linux-x86_64.sh
+      "https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-$(uname)-$(uname -m).sh" \
+      && bash /tmp/Miniforge3-$(uname)-$(uname -m).sh -b -p /opt/conda \
+      && rm /tmp/Miniforge3-$(uname)-$(uname -m).sh
 
     export PATH=/opt/conda/bin:$PATH
 
@@ -31,3 +31,4 @@ From: ubuntu:latest
     export PATH=/opt/conda/bin:$PATH
     export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
     export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
+


### PR DESCRIPTION
Changed the Miniforge install lines following the example code on the Miniforge github website:
  https://github.com/conda-forge/miniforge

Tested on x86_64 and aarch64 (nvidia Grace Hopper node)

Tony