### PR TITLE
Open Force Field toolkit container example

### DIFF
--- a/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/README.md
+++ b/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/README.md
@@ -1,0 +1,100 @@
+# Example Open Force Field toolkit container
+
+Please Note: the graphical part of openff-toolkit does not work at CCR because "nglview" must be run in a browser
+
+## Building the container
+
+A brief guide to building the openff-toolkit container follows:<br/>
+Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more detailed information on building and using Apptainer.
+
+1. Start an interactive job
+
+Apptainer is not available on the CCR login nodes and the compile nodes may not provide enough resources for you to build a container.  We recommend requesting an interactive job on a compute node to conduct this build process.<br/>
+See CCR docs for more info on [running jobs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission)
+
+```
+$ salloc --cluster=ub-hpc --partition=debug --qos=debug --mem=64GB --time=01:00:00
+salloc: Pending job allocation 19781052
+salloc: job 19781052 queued and waiting for resources
+salloc: job 19781052 has been allocated resources
+salloc: Granted job allocation 19781052
+salloc: Nodes cpn-i14-39 are ready for job
+CCRusername@cpn-i14-39:~$ 
+
+```
+
+2. Navigate to your build directory & set a temp directory for cache
+
+You should now be on the compute node allocated to you.  In this example we're using our project directory for our build directory.  Ensure you've placed your `openff-toolkit.def` and `environment.yml` file in your build directory
+
+```
+CCRusername@cpn-i14-39:~$ cd /projects/academic/[YourGroupName]/[CCRusername]
+CCRusername@cpn-i14-39:~$ mkdir cache
+CCRusername@cpn-i14-39:~$ export APPTAINER_CACHEDIR=/projects/academic/[YourGroupName]/[CCRusername]/cache
+
+```
+
+3. Build your container
+
+```
+CCRusername@cpn-i14-39:~$ apptainer build openff-toolkit-$(arch).sif openff-toolkit.def
+...
+...
+INFO:    Adding environment to container
+INFO:    Creating SIF file...
+INFO:    Build complete: openff-toolkit-x86_64.sif
+```
+
+## Running the container
+
+Start an interactive job e.g.
+
+```
+$ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --mem=128GB --nodes=1 --cpus-per-task=1 --tasks-per-node=32 --time=05:00:00
+```
+
+...then run the container
+
+
+```
+CCRusername@cpn-q06-35-02:~$ cd /projects/academic/[YourGroupName]/[CCRusername]
+CCRusername@cpn-q06-35-02$ apptainer exec -B /scratch:/scratch,/projects:/projects openff-toolkit-$(arch).sif python
+Python 3.12.10 | packaged by conda-forge | (main, Apr 10 2025, 22:21:13) [GCC 13.3.0] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> 
+```
+
+Alternatively, you can first get shell access into the container and then run Python, as shown here:
+
+```
+CCRusername@@cpn-q06-35-02:~$ apptainer shell -B /scratch:/scratch,/projects:/projects openff-toolkit-$(arch).sif
+Apptainer> python
+Python 3.12.10 | packaged by conda-forge | (main, Apr 10 2025, 22:21:13) [GCC 13.3.0] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> 
+```
+
+In either case, once you are in python you can use the Open Force Field toolkit<br/>
+For example:
+
+```
+>>> from openff.toolkit import Molecule, Topology
+>>> from openff.toolkit.utils import get_data_file_path
+>>> m = Molecule.from_smiles("CCCCOCC")
+>>> m.generate_conformers()
+>>> 
+```
+
+Unfortunately "nglview", the Python widget to interactively view molecular structures and trajectories, does not work at CCR; hence the following produces an empty output:
+
+```
+>>> import nglview
+>>> m.visualize(backend="nglview")
+NGLWidget()
+>>> 
+```
+
+We hope to address this in the future.<br/>
+
+See the [Open Force Field toolkit](https://docs.openforcefield.org/projects/toolkit/en/stable) website and the [Open Force Field](https://openforcefield.org) website for more info on Open Force Field
+

--- a/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/environment.yml
+++ b/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/environment.yml
@@ -1,0 +1,15 @@
+name: openff-toolkit
+channels:
+  - conda-forge
+  - nvidia
+dependencies:
+  - nvidia::cuda
+  - conda-forge::gcc=13.3.0
+  - conda-forge::python=3.12
+  - conda-forge::pip
+  - conda-forge::ambertools
+  - conda-forge::openff-toolkit
+  - conda-forge::ipywidgets
+  - conda-forge::notebook
+  - conda-forge::nglview
+

--- a/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/openff-toolkit.def
+++ b/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/openff-toolkit.def
@@ -1,0 +1,46 @@
+Bootstrap: docker
+From: ubuntu:latest
+
+%files
+    environment.yml     /opt/OpenFF/environment.yml
+
+%post
+
+    apt update
+    DEBIAN_FRONTEND=noninteractive apt install --yes \
+        locales \
+        wget \
+        unzip
+
+    echo "These steps are necessary to configure Perl and can cause issues with Python if omitted"
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+    dpkg-reconfigure --frontend=noninteractive locales
+    update-locale LANG=en_US.UTF-8
+
+    wget -P /tmp \
+      "https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-$(uname)-$(uname -m).sh" \
+      && bash /tmp/Miniforge3-$(uname)-$(uname -m).sh -b -p /opt/conda \
+      && rm /tmp/Miniforge3-$(uname)-$(uname -m).sh
+
+    export PATH=/opt/conda/bin:$PATH
+
+    mamba env update -n base --file /opt/OpenFF/environment.yml
+
+    #
+    # To install and use the Cadance OpenEye toolkits with the OpenFF Toolkit
+    # you MUST obtain a software license (free for academic use and teaching)
+    # see:
+    #
+    #    https://www.eyesopen.com/academic-licensing
+    #
+    # Then uncomment the following line:
+    #mamba install -n base -c openeye openeye-toolkits
+
+    mamba clean --all
+
+%environment
+    export LANG=en_US.UTF-8
+    export PATH=/opt/conda/bin:$PATH
+    export LIBRARY_PATH=$CONDA_PREFIX/lib:$LIBRARY_PATH
+    export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
+


### PR DESCRIPTION
The Open Force Field toolkit works within the container, however "nglview", the Python widget to interactively view molecular structures and trajectories, does not work at CCR
nglview does work if you download the .sif file and run jupyter-notebook inside the container on your PC.

Tony