### PR TITLE
Add Example Workflow for `container-mod`

### DIFF
--- a/containers/1_Advanced/README.md
+++ b/containers/1_Advanced/README.md
@@ -2,7 +2,7 @@
 
 ## How to use
 
-This directory contains complex containerized application setups and workflow examples. Currently, the directory includes an example workflow demonstrating how to use [`container-mod`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md) at CCR. Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information
+This directory contains complex containerized application setups and workflow examples. Currently, the directory includes an example workflow demonstrating how to use [`container-mod`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md) on the CCR software environment. Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information
 
 ## Additional Information
 

--- a/containers/1_Advanced/README.md
+++ b/containers/1_Advanced/README.md
@@ -1,9 +1,11 @@
 # Advanced Container Examples
 
-This directory contains an example workflow of `container-mod`.
-
-Here will be the example:
-
 ## How to use
 
+This directory contains complex containerized application setups and workflow examples. Currently, the directory includes an example workflow demonstrating how to use [`container-mod`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md) at CCR. Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information
 
+## Additional Information
+
+- The [Slurm README](../../slurm/README.md) provides details on general Slurm usage.
+- The [Placeholders](../../README.md#placeholders) section lists the available options for each placeholder used in commands and example scripts.
+- The [slurm-options.bash](../../slurm/slurm-options.bash) file outlines commonly used `#SBATCH` directives with their descriptions.

--- a/containers/1_Advanced/README.md
+++ b/containers/1_Advanced/README.md
@@ -1,7 +1,9 @@
 # Advanced Container Examples
 
- TODO: write me
+This directory contains an example workflow of `container-mod`.
+
+Here will be the example:
 
 ## How to use
 
-TODO: write me
+

--- a/containers/1_Advanced/README.md
+++ b/containers/1_Advanced/README.md
@@ -2,7 +2,7 @@
 
 ## How to use
 
-This directory contains complex containerized application setups and workflow examples. Currently, the directory includes an example workflow demonstrating how to use [`container-mod`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md) on the CCR software environment. Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information
+This directory contains complex containerized application setups and workflow examples. Currently, the directory includes two example workflows demonstrating how to use [`container-mod`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md) on the CCR software environment. Please refer to CCR's [container documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/) for more information
 
 ## Additional Information
 

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -43,7 +43,7 @@ For detailed information about the topics above and the available options for us
 	- Application name, version, description, homepage URL 
 	- Available programs: Software commands used to trigger certain behaviors (E.g., fds, abaqus, OpenSees, etc.) 
 
-For an example metadata file, please refern to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
+For an example metadata file, please refer to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
 
 4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file if script finishes successfully.
 

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -50,9 +50,9 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 	module use ~/privatemodules
 	```
 	- Edit the `~/.ccr/modulepaths` file to include the full path
-	- Or add the module use command in your `~/.bashrc` so it gets executed at startup (use at your own risk) 
+	- Or add the above `module use` command in your `~/.bashrc` so it gets executed at startup (use at your own risk) 
 
-6. Once done, verify with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
+6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
 
 7. Load the module using `module load` and verify the software executables work as expected:
 ```

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -1,0 +1,57 @@
+# container-mod Example Workflow
+
+In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with container-Mod to generate a ready-to-use environment module. We will use personal mode, where all files are generated in user's `$HOME` directory. More details can be found in our [documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod).
+
+1. Clone the [container-Mod repository](https://github.com/TuftsRT/container-mod) into your working directory.
+
+**Important files and their descriptions**
+- `container-Mod`: Main executable script
+- `repos/`: Stores all metadata for all software used by commands such as `module spider`
+- `profiles/`: Stores different profiles that define where generated files are placed, instead of the default personal mode (`$HOME`)
+
+**Generated Directories and Files (Personal Mode)**
+- `~/container-apps/`: Directory created in personal that contains all files and resources used by the generated module
+	a. `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
+	b. `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
+	c. `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
+- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
+
+**Subcommands used with the `container-mod` script**
+- `pull`: Pulls a container image into the desired directory
+- `module`: Generates the module file
+- `exec`: Generates wrapper scripts (subcommands for the software)
+- `pipe`: Important and most useful container-mod command; runs pull, module and exec in sequence
+
+> [!IMPORTANT]
+> To use container-mod, first make sure to request an interactive job to utilize Apptainer.
+
+2. Run the container-mod script with one of the above commands, followed by the image location. Sample command:
+```
+./container-mod  pipe  docker://satcomx00/fds:6.7.9
+```
+(You can also use local images (e.g. from /util/software/containers/), pipe will not pull the image, local images stay in their location) 
+
+> [!NOTE]
+> If no profile is selected, container-mod will run in personal mode (all related files will get generated in $HOME).
+
+3. If container-mod doesn’t find any software-related files beforehand (module, metadata, executable files), it will ask the following info only once:
+- Application name, version, description, homepage URL 
+- Available programs: Software commands used to trigger certain behaviors (abaqus, OpenSees, etc.) 
+
+4. Once info is provided, container-mod will execute Apptainer commands on the image and generate module files if script finishes successfully.
+
+5. To use the generated modules, you will need to edit the $MODULEPATH to include the full ~/privatemodules path, and you can do this in a few ways:
+- Use the command: 
+```
+module use ~/privatemodules (Only eligible for the current session) 
+```
+- Edit the ~/.ccr/modulepaths file to include the full path
+- Or add the module use command in your ~/.bashrc so its gets executed at startup (use at your own risk) 
+
+Once done, verify with commands like echo $MODULEPATH, module avail, show, spider etc. 
+
+6. Load the module with module load and verify the software executables (software commands) work as expected. Example command:
+```
+module show fds/6.7.9
+module load fds/6.7.9
+```

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -36,7 +36,7 @@ For detailed information about the topics above and the available options for us
 (You can also use local images (e.g. from /util/software/containers/); local images stay in their original location) 
 
 > [!NOTE]
-> Currently, we only support personal mode and cannot guarantee functionality with profiles. If no profile is selected, `container-mod` will run in personal mode (all files will be generated in user's `$HOME`).
+> Currently, CCR only supports personal mode and cannot guarantee functionality with profiles.
 
 3. If there are no software-related files beforehand (module, metadata, executable files), the script will ask the following info only once to create a new entry:
 
@@ -47,7 +47,7 @@ For an example metadata file, please refer to the official `container-mod` [READ
 
 4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file if script finishes successfully.
 
-5. To use the generated module, you will need to edit your `$MODULEPATH` to include the new path: `/user/[CCRUsername]/privatemodules`. You can do this in a few ways:
+5. To use the newly generated module, you will need to edit your `$MODULEPATH` to include: `/user/[CCRUsername]/privatemodules`. You can do this in a few ways:
 
 	- Use the command (Only eligible for the current session): 
 	```

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -1,16 +1,18 @@
 # container-mod Example Workflow
 
-In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with container-Mod to generate a ready-to-use environment module. We will use personal mode, where all files are generated in user's `$HOME` directory. More details can be found in our [documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod).
+In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with container-mod to generate a ready-to-use environment module. We will use personal mode, where all files are generated in user's `$HOME` directory. More details can be found in our [documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod).
 
-1. Clone the [container-Mod repository](https://github.com/TuftsRT/container-mod) into your working directory.
+## How to use
+
+1. Clone the [container-mod repository](https://github.com/TuftsRT/container-mod) into your working directory.
 
 **Important files and their descriptions**
-- `container-Mod`: Main executable script
+- `container-mod`: Main executable script
 - `repos/`: Stores all metadata for all software used by commands such as `module spider`
 - `profiles/`: Stores different profiles that define where generated files are placed, instead of the default personal mode (`$HOME`)
 
 **Generated Directories and Files (Personal Mode)**
-- `~/container-apps/`: Directory created in personal that contains all files and resources used by the generated module
+- `~/container-apps/`: Directory created in personal mode and contains all files and resources used by the generated module
 	a. `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
 	b. `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
 	c. `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
@@ -20,38 +22,42 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 - `pull`: Pulls a container image into the desired directory
 - `module`: Generates the module file
 - `exec`: Generates wrapper scripts (subcommands for the software)
-- `pipe`: Important and most useful container-mod command; runs pull, module and exec in sequence
+- `pipe`: Important and most useful container-mod command; **runs pull, module and exec in sequence**
 
 > [!IMPORTANT]
 > To use container-mod, first make sure to request an interactive job to utilize Apptainer.
 
-2. Run the container-mod script with one of the above commands, followed by the image location. Sample command:
+2. Run the `container-mod` script with one of the above Subcommands, followed by the image location. For Example:
 ```
-./container-mod  pipe  docker://satcomx00/fds:6.7.9
+./container-mod pipe docker://satcomx00/fds:6.7.9
 ```
-(You can also use local images (e.g. from /util/software/containers/), pipe will not pull the image, local images stay in their location) 
+(You can also use local images (e.g. from /util/software/containers/); local images stay in their original location) 
 
 > [!NOTE]
-> If no profile is selected, container-mod will run in personal mode (all related files will get generated in $HOME).
+> If no profile is selected, `container-mod` will run in personal mode (all related files will get generated in user's `$HOME`).
 
-3. If container-mod doesn’t find any software-related files beforehand (module, metadata, executable files), it will ask the following info only once:
+3. If there are no software-related files beforehand (module, metadata, executable files), it will ask the following info only once:
+
 - Application name, version, description, homepage URL 
 - Available programs: Software commands used to trigger certain behaviors (abaqus, OpenSees, etc.) 
 
-4. Once info is provided, container-mod will execute Apptainer commands on the image and generate module files if script finishes successfully.
+4. Once the information is provided, `container-mod` will execute Apptainer commands on the image and generate module files if script finishes successfully.
 
-5. To use the generated modules, you will need to edit the $MODULEPATH to include the full ~/privatemodules path, and you can do this in a few ways:
-- Use the command: 
+5. To use the generated modules, you will need to edit your `$MODULEPATH` to include the new path where your module has been generated. You can do this in a few ways:
+
+- Use the command (Only eligible for the current session): 
 ```
-module use ~/privatemodules (Only eligible for the current session) 
+module use ~/privatemodules
 ```
-- Edit the ~/.ccr/modulepaths file to include the full path
-- Or add the module use command in your ~/.bashrc so its gets executed at startup (use at your own risk) 
+- Edit the `~/.ccr/modulepaths` file to include the full path
+- Or add the module use command in your `~/.bashrc` so it gets executed at startup (use at your own risk) 
 
-Once done, verify with commands like echo $MODULEPATH, module avail, show, spider etc. 
+Once done, verify with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
 
-6. Load the module with module load and verify the software executables (software commands) work as expected. Example command:
+6. Load the module with module load and verify the software executables work as expected:
 ```
 module show fds/6.7.9
 module load fds/6.7.9
 ```
+
+Congratulations! You've just built your own module!! 

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -1,6 +1,6 @@
 # container-mod Example Workflow
 
-In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with container-mod to generate a ready-to-use environment module. We will use personal mode, where all files are generated in user's `$HOME` directory. More details can be found in our [documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod).
+In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with container-mod to generate a ready-to-use environment module. We will use personal mode, where all files are generated in user's `$HOME` directory. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
 
 ## How to use
 
@@ -11,18 +11,18 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 - `repos/`: Stores all metadata for all software used by commands such as `module spider`
 - `profiles/`: Stores different profiles that define where generated files are placed, instead of the default personal mode (`$HOME`)
 
-**Generated Directories and Files (Personal Mode)**
-- `~/container-apps/`: Directory created in personal mode and contains all files and resources used by the generated module
-	a. `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
-	b. `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
-	c. `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
-- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
-
 **Subcommands used with the `container-mod` script**
 - `pull`: Pulls a container image into the desired directory
 - `module`: Generates the module file
 - `exec`: Generates wrapper scripts (subcommands for the software)
 - `pipe`: Important and most useful container-mod command; **runs pull, module and exec in sequence**
+
+**Generated Directories and Files (Personal Mode)**
+- `~/container-apps/`: Directory created in personal mode and contains all files and resources used by the generated module
+	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
+	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
+	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
+- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
 
 > [!IMPORTANT]
 > To use container-mod, first make sure to request an interactive job to utilize Apptainer.
@@ -38,26 +38,26 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 
 3. If there are no software-related files beforehand (module, metadata, executable files), it will ask the following info only once:
 
-- Application name, version, description, homepage URL 
-- Available programs: Software commands used to trigger certain behaviors (abaqus, OpenSees, etc.) 
+	- Application name, version, description, homepage URL 
+	- Available programs: Software commands used to trigger certain behaviors (E.g., fds, abaqus, OpenSees, etc.) 
 
 4. Once the information is provided, `container-mod` will execute Apptainer commands on the image and generate module files if script finishes successfully.
 
 5. To use the generated modules, you will need to edit your `$MODULEPATH` to include the new path where your module has been generated. You can do this in a few ways:
 
-- Use the command (Only eligible for the current session): 
-```
-module use ~/privatemodules
-```
-- Edit the `~/.ccr/modulepaths` file to include the full path
-- Or add the module use command in your `~/.bashrc` so it gets executed at startup (use at your own risk) 
+	- Use the command (Only eligible for the current session): 
+	```
+	module use ~/privatemodules
+	```
+	- Edit the `~/.ccr/modulepaths` file to include the full path
+	- Or add the module use command in your `~/.bashrc` so it gets executed at startup (use at your own risk) 
 
-Once done, verify with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
+6. Once done, verify with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
 
-6. Load the module with module load and verify the software executables work as expected:
+7. Load the module using `module load` and verify the software executables work as expected:
 ```
-module show fds/6.7.9
 module load fds/6.7.9
+fds
 ```
 
 Congratulations! You've just built your own module!! 

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -17,12 +17,14 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 - `exec`: Generates wrapper scripts (subcommands for the software)
 - `pipe`: Important and most useful container-mod command; **runs pull, module and exec in sequence**
 
-**Generated Directories and Files (Personal Mode)**
+**Generated directories and files (Personal Mode)**
 - `~/container-apps/`: Directory created in personal mode and contains all files and resources used by the generated module
 	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
 	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
 	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
 - `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
+
+For detailed information about the topics above and the available options for use, please refer to the [official documentation](https://github.com/TuftsRT/container-mod#usage).
 
 > [!IMPORTANT]
 > To use container-mod, first make sure to request an interactive job to utilize Apptainer.
@@ -34,16 +36,18 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 (You can also use local images (e.g. from /util/software/containers/); local images stay in their original location) 
 
 > [!NOTE]
-> If no profile is selected, `container-mod` will run in personal mode (all related files will get generated in user's `$HOME`).
+> If no profile is selected, `container-mod` will run in personal mode (all files will be generated in user's `$HOME`). For more information about profiles, please refer to the [official documentation](https://github.com/TuftsRT/container-mod#profiles).
 
-3. If there are no software-related files beforehand (module, metadata, executable files), it will ask the following info only once:
+3. If there are no software-related files beforehand (module, metadata, executable files), the script will ask the following info only once to create a new entry:
 
 	- Application name, version, description, homepage URL 
 	- Available programs: Software commands used to trigger certain behaviors (E.g., fds, abaqus, OpenSees, etc.) 
 
-4. Once the information is provided, `container-mod` will execute Apptainer commands on the image and generate module files if script finishes successfully.
+For an example metadata file, please refern to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
 
-5. To use the generated modules, you will need to edit your `$MODULEPATH` to include the new path where your module has been generated. You can do this in a few ways:
+4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file if script finishes successfully.
+
+5. To use the generated module, you will need to edit your `$MODULEPATH` to include the new path where your module has been generated. You can do this in a few ways:
 
 	- Use the command (Only eligible for the current session): 
 	```

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -1,6 +1,6 @@
 # container-mod Example Workflow
 
-In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with container-mod to generate a ready-to-use environment module. We will use personal mode, where all files are generated in user's `$HOME` directory. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
+In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with `container-mod` to generate a ready-to-use environment module. We will use personal mode, where all files are generated in the user's `$HOME` directory. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
 
 ## How to use
 
@@ -8,7 +8,7 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 
 **Important files and their descriptions**
 - `container-mod`: Main executable script
-- `repos/`: Stores all metadata for all software used by commands such as `module spider`
+- `repos/`: Stores metadata for all software used by commands such as `module spider`
 - `profiles/`: Stores different profiles that define where generated files are placed, instead of the default personal mode (`$HOME`)
 
 **Subcommands used with the `container-mod` script**
@@ -18,25 +18,25 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 - `pipe`: Important and most useful container-mod command; **runs pull, module and exec in sequence**
 
 **Generated directories and files (Personal Mode)**
+- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
 - `~/container-apps/`: Directory created in personal mode and contains all files and resources used by the generated module
 	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
 	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
 	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
-- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
 
 For detailed information about the topics above and the available options for use, please refer to the [official documentation](https://github.com/TuftsRT/container-mod#usage).
 
 > [!IMPORTANT]
 > To use container-mod, first make sure to request an interactive job to utilize Apptainer.
 
-2. Run the `container-mod` script with one of the above Subcommands, followed by the image location. For Example:
+2. Run the `container-mod` script with one of the above Subcommands, followed by the image location. For example:
 ```
 ./container-mod pipe docker://satcomx00/fds:6.7.9
 ```
 (You can also use local images (e.g. from /util/software/containers/); local images stay in their original location) 
 
 > [!NOTE]
-> If no profile is selected, `container-mod` will run in personal mode (all files will be generated in user's `$HOME`). For more information about profiles, please refer to the [official documentation](https://github.com/TuftsRT/container-mod#profiles).
+> Currently, we only support personal mode and cannot guarantee functionality with profiles. If no profile is selected, `container-mod` will run in personal mode (all files will be generated in user's `$HOME`).
 
 3. If there are no software-related files beforehand (module, metadata, executable files), the script will ask the following info only once to create a new entry:
 
@@ -47,14 +47,13 @@ For an example metadata file, please refer to the official `container-mod` [READ
 
 4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file if script finishes successfully.
 
-5. To use the generated module, you will need to edit your `$MODULEPATH` to include the new path where your module has been generated. You can do this in a few ways:
+5. To use the generated module, you will need to edit your `$MODULEPATH` to include the new path: `/user/[CCRUsername]/privatemodules`. You can do this in a few ways:
 
 	- Use the command (Only eligible for the current session): 
 	```
 	module use ~/privatemodules
 	```
-	- Edit the `~/.ccr/modulepaths` file to include the full path
-	- Or add the above `module use` command in your `~/.bashrc` so it gets executed at startup (use at your own risk) 
+	- Edit the `~/.ccr/modulepaths` file to include `/user/[CCRUsername]/privatemodules`.
 
 6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
 
@@ -64,4 +63,4 @@ module load fds/6.7.9
 fds
 ```
 
-Congratulations! You've just built your own module!! 
+Congratulations! You've just built your own container module!! 

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -14,12 +14,12 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 **Subcommands used with the `container-mod` script**
 - `pull`: Pulls a container image into the desired directory
 - `module`: Generates the module file
-- `exec`: Generates wrapper scripts (subcommands for the software)
+- `exec`: Generates wrapper scripts (executables for specific software programs)
 - `pipe`: Important and most useful container-mod command; **runs pull, module and exec in sequence**
 
 **Generated directories and files (Personal Mode)**
 - `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
-- `~/container-apps/`: Directory created in personal mode and contains all files and resources used by the generated module
+- `~/container-apps/`: Contains all files and resources used by the generated module
 	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
 	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
 	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
@@ -27,7 +27,7 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 For detailed information about the topics above and the available options for use, please refer to the [official documentation](https://github.com/TuftsRT/container-mod#usage).
 
 > [!IMPORTANT]
-> To use container-mod, first make sure to request an interactive job to utilize Apptainer.
+> To use container-mod, first make sure to request an [interactive job](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission) to utilize Apptainer.
 
 2. Run the `container-mod` script with one of the above Subcommands, followed by the image location. For example:
 ```
@@ -45,7 +45,7 @@ For detailed information about the topics above and the available options for us
 
 For an example metadata file, please refer to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
 
-4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file if script finishes successfully.
+4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file and solicited wrapper scripts, if the main script finishes successfully.
 
 5. To use the newly generated module, you will need to edit your `$MODULEPATH` to include: `/user/[CCRUsername]/privatemodules`. You can do this in a few ways:
 
@@ -55,7 +55,7 @@ For an example metadata file, please refer to the official `container-mod` [READ
 	```
 	- Edit the `~/.ccr/modulepaths` file to include `/user/[CCRUsername]/privatemodules`.
 
-6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `show`, `spider` etc. 
+6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `module show`, etc. 
 
 7. Load the module using `module load` and verify the software executables work as expected:
 ```

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -1,66 +1,53 @@
-# container-mod Example Workflow
+# container-mod Example Workflows
 
-In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with `container-mod` to generate a ready-to-use environment module. We will use personal mode, where all files are generated in the user's `$HOME` directory. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
+This directory contains two example workflows ([`personal/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/personal) and [`project/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/project)). The `personal` workflow utilizes a container from DockerHub and runs in default (`personal`) mode. The `project` example is based on a locally stored `.sif` file and an example profile for `container-mod`. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
 
 ## How to use
 
 1. Clone the [container-mod repository](https://github.com/TuftsRT/container-mod) into your working directory.
 
-**Important files and their descriptions**
+**Important files and directories**
 - `container-mod`: Main executable script
-- `repos/`: Stores metadata for all software used by commands such as `module spider`
-- `profiles/`: Stores different profiles that define where generated files are placed, instead of the default personal mode (`$HOME`)
+- `repos/`: Stores metadata for all software. Used by commands like `module spider`
+- `profiles/`: Stores different profiles that define where output files are generated (instead of the default `personal` mode)
 
 **Subcommands used with the `container-mod` script**
 - `pull`: Pulls a container image into the desired directory
 - `module`: Generates the module file
 - `exec`: Generates wrapper scripts (executables for specific software programs)
-- `pipe`: Important and most useful container-mod command; **runs pull, module and exec in sequence**
+- `pipe`: **Most useful container-mod command**; Runs pull, module and exec in sequence
 
-**Generated directories and files (Personal Mode)**
-- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
-- `~/container-apps/`: Contains all files and resources used by the generated module
-	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub. (Local images stay in their original location)
-	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
-	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
+**Useful Options**
+- `--profile`: Loads the specified profile stored in `profiles/`
+- `--write-to-profile-dirs`: Writes output to the directories from the profile, rather than the profile defaults
+- `-c, --container-app`: Used to explicitly specify the container application, `apptainer` in our case
+- `-j, --jupyter`: Creates a Jupyter kernel for the containerized software, if compatible
+- `-h, --help`: For built-in help
 
-For detailed information about the topics above and the available options for use, please refer to the [official documentation](https://github.com/TuftsRT/container-mod#usage).
+For detailed information about the topics above and additional options, please refer to the official [`container-mod` README](https://github.com/TuftsRT/container-mod#usage).
+
+2. Start an interactive job
 
 > [!IMPORTANT]
-> To use container-mod, first make sure to request an [interactive job](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission) to utilize Apptainer.
+> Apptainer is not available on the CCR login nodes and the compile nodes may not provide enough resources for you to build a container.  We recommend requesting an interactive job on a compute node to conduct this build process.<br/>
+> See CCR docs for more info on [running jobs](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission).
 
-2. Run the `container-mod` script with one of the above Subcommands, followed by the image location. For example:
 ```
-./container-mod pipe docker://satcomx00/fds:6.7.9
-```
-(You can also use local images (e.g. from /util/software/containers/); local images stay in their original location) 
-
-> [!NOTE]
-> Currently, CCR only supports personal mode and cannot guarantee functionality with profiles.
-
-3. If there are no software-related files beforehand (module, metadata, executable files), the script will ask the following info only once to create a new entry:
-
-	- Application name, version, description, homepage URL 
-	- Available programs: Software commands used to trigger certain behaviors (E.g., fds, abaqus, OpenSees, etc.) 
-
-For an example metadata file, please refer to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
-
-4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file and solicited wrapper scripts, if the main script finishes successfully.
-
-5. To use the newly generated module, you will need to edit your `$MODULEPATH` to include: `/user/[CCRUsername]/privatemodules`. You can do this in a few ways:
-
-	- Use the command (Only eligible for the current session): 
-	```
-	module use ~/privatemodules
-	```
-	- Edit the `~/.ccr/modulepaths` file to include `/user/[CCRUsername]/privatemodules`.
-
-6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `module show`, etc. 
-
-7. Load the module using `module load` and verify the software executables work as expected:
-```
-module load fds/6.7.9
-fds
+salloc --cluster=ub-hpc --partition=debug --qos=debug --exclusive --time=01:00:00
 ```
 
-Congratulations! You've just built your own container module!! 
+Sample output:
+```
+salloc: Pending job allocation [JobID]
+salloc: job [JobID] queued and waiting for resources
+salloc: job [JobID] has been allocated resources
+salloc: Granted job allocation [JobID]
+salloc: Nodes [NodeID] are ready for job
+CCRusername@[NodeID]:~$
+```
+
+3. Choose between one of the following workflows according to your use case:
+- [`personal/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/personal)
+- [`project/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/project)
+
+Refer to the official `container-mod` [repository](https://github.com/TuftsRT/container-mod) for more information.

--- a/containers/1_Advanced/container-mod/README.md
+++ b/containers/1_Advanced/container-mod/README.md
@@ -1,6 +1,6 @@
 # container-mod Example Workflows
 
-This directory contains two example workflows ([`personal/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/personal) and [`project/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/project)). The `personal` workflow utilizes a container from DockerHub and runs in default (`personal`) mode. The `project` example is based on a locally stored `.sif` file and an example profile for `container-mod`. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
+This directory contains two example workflows ([`personal/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/personal) and [`project/`](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/project)) for `container-mod`. The `personal` workflow utilizes a FDS container from DockerHub and runs in default (`personal`) mode. The `project` example is based on a locally stored `.sif` file and an example profile for `container-mod`. More details can be found in [CCR's documentation](https://docs.ccr.buffalo.edu/en/latest/howto/containerization/#container-mod) for `container-mod`.
 
 ## How to use
 

--- a/containers/1_Advanced/container-mod/personal/README.md
+++ b/containers/1_Advanced/container-mod/personal/README.md
@@ -1,0 +1,42 @@
+# container-mod Personal Mode Example
+
+In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with `container-mod` to generate a ready-to-use environment module. We will use personal mode, where all files are generated in the user's `$HOME` directory. This example extends the [container-mod README](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md). For more information, please refer to it.
+
+**Generated directories and files in Personal Mode**
+- `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
+- `~/container-apps/`: Contains all files and resources used by the generated module
+	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub.
+	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
+	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
+
+2. To use container-mod, first make sure to request an [interactive job](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission) to utilize Apptainer.
+
+3. Run the `container-mod` script with the `pipe` subcommand, followed by the image location. For example:
+```
+./container-mod pipe docker://satcomx00/fds:6.7.9
+```
+
+4. If there are no software-related files beforehand (module, metadata, executable files), the script will ask the following info only once to create a new entry:
+
+	- Application name, version, description, homepage URL 
+	- Available programs: Software commands used to trigger certain behaviors (E.g., fds, abaqus, OpenSees, etc.) 
+
+For an example metadata file, please refer to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
+
+4. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file and requested wrapper scripts for programs, if the main script finishes successfully.
+
+5. To use the newly generated module, you will need to edit the `$MODULEPATH` env. variable to include the full path to the modulefile (`/user/[CCRUsername]/privatemodules`). You can do this in a few ways:
+
+	- Use the command (Only eligible for the current session): 
+	```
+	module use ~/privatemodules
+	```
+	- Edit the `~/.ccr/modulepaths` file to include `/user/[CCRUsername]/privatemodules`.
+
+6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `module show`, etc. 
+
+7. Load the module using `module load` and verify the software executables work as expected:
+```
+module load fds/6.7.9
+fds
+```

--- a/containers/1_Advanced/container-mod/personal/README.md
+++ b/containers/1_Advanced/container-mod/personal/README.md
@@ -1,6 +1,6 @@
 # container-mod Personal Mode Example
 
-In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with `container-mod` to generate a ready-to-use environment module. We will use personal mode, where all files are generated in the user's `$HOME` directory. This example extends the [container-mod README](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md). For more information, please refer to it.
+In this example, we'll use the FDS container image from [DockerHub](https://hub.docker.com/r/satcomx00/fds) and process it with `container-mod` to generate a ready-to-use environment module. We will use the default (`personal`) mode, where all files are generated in the user's `$HOME` directory. This example extends the [container-mod README](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md). For more information, please refer to it.
 
 **Generated directories and files in Personal Mode**
 - `~/privatemodules/`: Stores generated modulefiles (`.lua`) for Lmod
@@ -8,6 +8,8 @@ In this example, we'll use the FDS container image from [DockerHub](https://hub.
 	- `container-apps/images/`: Stores container images pulled from registries such as DockerHub.
 	- `container-apps/repos/`: Contains metadata for all configured software, used by commands like `module spider`
 	- `container-apps/tools/`: Holds generated executables (wrapper scripts) for using specific software programs
+
+## Workflow
 
 2. To use container-mod, first make sure to request an [interactive job](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission) to utilize Apptainer.
 

--- a/containers/1_Advanced/container-mod/project/README.md
+++ b/containers/1_Advanced/container-mod/project/README.md
@@ -1,0 +1,56 @@
+# container-mod Sample Profile Example
+
+In this example, we'll use the Abaqus 2024 container image stored locally at `/util/software/containers/x86-64/abaqus-2024.sif`. We will use the `--profile` option with a custom profile to generate `container-mod` output files in your group's project directory, creating a ready-to-use shared Abaqus container module. This example extends the [container-mod README](https://github.com/ubccr/ccr-examples/tree/main/containers/1_Advanced/container-mod/README.md). For more information, please refer to it. 
+
+## Creating a Custom Profile
+
+Profiles are simple shell files stored in the `profiles/` directory. They define where `container-mod` stores generated output files and include the following:
+-`MOD_EXISTING_DIR_DEF`: Directory to store the generated Lmod modulefile (`.lua`)
+-`PUBLIC_IMAGEDIR`: Stores container images pulled from online registries. (Local images stay in their original location)
+-`PUBLIC_EXECUTABLE_DIR`: Directory to store generated wrapper scripts
+-`BIND_PATH`: Paths to bind into the container
+
+For example, to generate output files and create a usable module for your project group [YourGroupName], create a file named `project` in the `profiles/` directory:
+```
+MOD_EXISTING_DIR_DEF="/projects/academic/[YourGroupName]/privatemodules"
+PUBLIC_IMAGEDIR="/projects/academic/[YourGroupName]/images"
+PUBLIC_EXECUTABLE_DIR="/projects/academic/[YourGroupName]/executables"
+BIND_PATH="/vscratch:/vscratch,/projects:/projects"
+```
+
+## Workflow
+
+2. To use container-mod, first make sure to request an [interactive job](https://docs.ccr.buffalo.edu/en/latest/hpc/jobs/#interactive-job-submission) to utilize Apptainer.
+
+3. Run the `container-mod` script with the `pipe` subcommand, specifying the profile, required options and the locally stored image. For example:
+```
+./container-mod pipe --profile project --write-to-profile-dirs --container-app apptainer /util/software/containers/x86-64/abaqus-2024.sif
+```
+
+>[!NOTE]
+>Local images stay in their original location
+
+4. If there are no software-related files beforehand (module, metadata, executable files), the script will ask the following info only once to create a new entry:
+
+	- Application name, version, description, homepage URL 
+	- Available programs: Software commands used to trigger certain behaviors (E.g., fds, abaqus, OpenSees, etc.) 
+
+For an example metadata file, please refer to the official `container-mod` [README](https://github.com/TuftsRT/container-mod#how-it-works).
+
+5. Once the required information is provided, `container-mod` will execute the necessary Apptainer commands on the image and automatically generate the module file and solicited wrapper scripts into the specified directories, if the main script finishes successfully.
+
+5. To use the newly generated module, you will need to edit the `$MODULEPATH` env. variable to include the full path to the modulefile. You can do this in a few ways:
+
+	- Use the command (Only eligible for the current session): 
+	```
+	module use /projects/academic/[YourGroupName]/privatemodules
+	```
+	- Edit the `~/.ccr/modulepaths` file to include `/projects/academic/[YourGroupName]/privatemodules`.
+
+6. Once done, verify `Lmod` recognizes the new module with commands like `echo $MODULEPATH`, `module avail`, `module show`, etc. 
+
+7. Load the module using `module load` and verify the software executables work as expected:
+```
+module load abaqus/2024
+abaqus
+```

--- a/containers/1_Advanced/container-mod/project/README.md
+++ b/containers/1_Advanced/container-mod/project/README.md
@@ -5,12 +5,12 @@ In this example, we'll use the Abaqus 2024 container image stored locally at `/u
 ## Creating a Custom Profile
 
 Profiles are simple shell files stored in the `profiles/` directory. They define where `container-mod` stores generated output files and include the following:
--`MOD_EXISTING_DIR_DEF`: Directory to store the generated Lmod modulefile (`.lua`)
--`PUBLIC_IMAGEDIR`: Stores container images pulled from online registries. (Local images stay in their original location)
--`PUBLIC_EXECUTABLE_DIR`: Directory to store generated wrapper scripts
--`BIND_PATH`: Paths to bind into the container
+- `MOD_EXISTING_DIR_DEF`: Directory to store the generated Lmod modulefile (`.lua`)
+- `PUBLIC_IMAGEDIR`: Stores container images pulled from online registries. (Local images stay in their original location)
+- `PUBLIC_EXECUTABLE_DIR`: Directory to store generated wrapper scripts
+- `BIND_PATH`: Paths to bind into the container
 
-For example, to generate output files and create a usable module for your project group [YourGroupName], create a file named `project` in the `profiles/` directory:
+For example, to generate output files and create a usable module for your project group (`[YourGroupName]`), create a file named `project` in the `profiles/` directory, containing:
 ```
 MOD_EXISTING_DIR_DEF="/projects/academic/[YourGroupName]/privatemodules"
 PUBLIC_IMAGEDIR="/projects/academic/[YourGroupName]/images"

--- a/containers/README.md
+++ b/containers/README.md
@@ -10,7 +10,7 @@ Here we present a minimalist example of container usage in CCR's HPC environment
 
 ## Advanced Topics ([Advanced/](./1_Advanced/README.md))
 
-Coming Soon
+This directory contains an example workflow for `container-mod`. More information can be found in there.
 
 ## Application Specific Containers ([ApplicationSpecific/](./2_ApplicationSpecific/README.md))
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -10,7 +10,7 @@ Here we present a minimalist example of container usage in CCR's HPC environment
 
 ## Advanced Topics ([Advanced/](./1_Advanced/README.md))
 
-This directory contains an example workflow for `container-mod`. More information can be found in there.
+This directory contains complex containerized application setups and workflow examples.
 
 ## Application Specific Containers ([ApplicationSpecific/](./2_ApplicationSpecific/README.md))
 


### PR DESCRIPTION
This example workflow will support CCR's forthcoming `container-mod` documentation  in `ccrdocs`.