### PR TITLE
Use subgroup-specific container bind mounts

### DIFF
--- a/containers/2_ApplicationSpecific/AlphaFold-3/BUILD-ARM64.md
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/BUILD-ARM64.md
@@ -105,7 +105,7 @@ mkdir -p ./af_input ./af_input_inference ./af_output
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  --nv \
  ./AlphaFold-3-$(arch).sif
 ```

--- a/containers/2_ApplicationSpecific/AlphaFold-3/EXAMPLE.md
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/EXAMPLE.md
@@ -46,7 +46,7 @@ Then run the AlphaFold-3 container:
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  ./AlphaFold-3-$(arch).sif
 ```
 
@@ -157,7 +157,7 @@ Then run the AlphaFold-3 container (with nvidia GPU support):
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  --nv \
  ./AlphaFold-3-$(arch).sif
 ```

--- a/containers/2_ApplicationSpecific/AlphaFold-3/README.md
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/README.md
@@ -114,7 +114,7 @@ mkdir -p ./af_input ./af_input_inference ./af_output
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  --nv \
  ./AlphaFold-3-$(arch).sif
 ```

--- a/containers/2_ApplicationSpecific/AlphaFold-3/slurm_AlphaFold-3_Data_Pipeline_example.bash
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/slurm_AlphaFold-3_Data_Pipeline_example.bash
@@ -42,7 +42,7 @@ mkdir -p ./af_input_inference ./af_output
 
 ## Run the Data Pipeline
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  ./AlphaFold-3-$(arch).sif \
  python3 "/app/alphafold/run_alphafold.py" \
  --db_dir="/util/software/data/alphafold3/" \
@@ -60,7 +60,7 @@ then
 fi
 
 ## get the output directory name for the Inference run
-AlphaFold_Inference_Input_Dir="$(apptainer exec -B ,/projects:/projects ./AlphaFold-3-$(arch).sif python3 -c "exec(open('/app/alphafold/src/alphafold3/common/folding_input.py', 'r').read()); inference_input_dir = Input(name=\"$(jq -r '.name' "${input_dir}/"*.json)\", chains=[], rng_seeds=[0]); print ('./af_input_inference/' + inference_input_dir.sanitised_name())" 2>&1 | tail -1)"
+AlphaFold_Inference_Input_Dir="$(apptainer exec -B /projects/academic/[YourGroupName]:/projects ./AlphaFold-3-$(arch).sif python3 -c "exec(open('/app/alphafold/src/alphafold3/common/folding_input.py', 'r').read()); inference_input_dir = Input(name=\"$(jq -r '.name' "${input_dir}/"*.json)\", chains=[], rng_seeds=[0]); print ('./af_input_inference/' + inference_input_dir.sanitised_name())" 2>&1 | tail -1)"
 
 ## submit an Inference job with the output from this Data Pipeline run
 echo "Submitting Inference job with the input directory \"${AlphaFold_Inference_Input_Dir}\""

--- a/containers/2_ApplicationSpecific/AlphaFold-3/slurm_AlphaFold-3_Inference_example.bash
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/slurm_AlphaFold-3_Inference_example.bash
@@ -44,7 +44,7 @@ echo "Running Inference with the input directory \"${AlphaFold_Inference_Input_D
 
 ## Run the Inference
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  --nv \
  ./AlphaFold-3-$(arch).sif \
  python3 "/app/alphafold/run_alphafold.py" \

--- a/containers/2_ApplicationSpecific/AlphaFold-3/slurm_GH200_AlphaFold-3_Data_Pipeline_example.bash
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/slurm_GH200_AlphaFold-3_Data_Pipeline_example.bash
@@ -42,7 +42,7 @@ mkdir -p ./af_input_inference ./af_output
 
 ## Run the Data Pipeline
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  ./AlphaFold-3-$(arch).sif \
  python3 "/app/alphafold/run_alphafold.py" \
  --db_dir="/util/software/data/alphafold3/" \
@@ -60,7 +60,7 @@ then
 fi
 
 ## get the output directory name for the Inference run
-AlphaFold_Inference_Input_Dir="$(apptainer exec -B ,/projects:/projects ./AlphaFold-3-$(arch).sif python3 -c "exec(open('/app/alphafold/src/alphafold3/common/folding_input.py', 'r').read()); inference_input_dir = Input(name=\"$(jq -r '.name' "${input_dir}/"*.json)\", chains=[], rng_seeds=[0]); print ('./af_input_inference/' + inference_input_dir.sanitised_name())" 2>&1 | tail -1)"
+AlphaFold_Inference_Input_Dir="$(apptainer exec -B /projects/academic/[YourGroupName]:/projects ./AlphaFold-3-$(arch).sif python3 -c "exec(open('/app/alphafold/src/alphafold3/common/folding_input.py', 'r').read()); inference_input_dir = Input(name=\"$(jq -r '.name' "${input_dir}/"*.json)\", chains=[], rng_seeds=[0]); print ('./af_input_inference/' + inference_input_dir.sanitised_name())" 2>&1 | tail -1)"
 
 ## submit an Inference job with the output from this Data Pipeline run
 echo "Submitting Inference job with the input directory \"${AlphaFold_Inference_Input_Dir}\""

--- a/containers/2_ApplicationSpecific/AlphaFold-3/slurm_GH200_AlphaFold-3_Inference_example.bash
+++ b/containers/2_ApplicationSpecific/AlphaFold-3/slurm_GH200_AlphaFold-3_Inference_example.bash
@@ -46,7 +46,7 @@ echo "Running Inference with the input directory \"${AlphaFold_Inference_Input_D
 
 ## Run the Inference
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  --nv \
  ./AlphaFold-3-$(arch).sif \
  python3 "/app/alphafold/run_alphafold.py" \

--- a/containers/2_ApplicationSpecific/BindCraft/BUILD_with_PyRosetta.md
+++ b/containers/2_ApplicationSpecific/BindCraft/BUILD_with_PyRosetta.md
@@ -102,7 +102,7 @@ mkdir -p ./input ./output
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \

--- a/containers/2_ApplicationSpecific/BindCraft/EXAMPLES.md
+++ b/containers/2_ApplicationSpecific/BindCraft/EXAMPLES.md
@@ -40,7 +40,7 @@ Note that the AlphaFold 2 params files are mounted on /app/params inside the con
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \
@@ -213,7 +213,7 @@ Start the container:
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \

--- a/containers/2_ApplicationSpecific/BindCraft/EXAMPLES_WITH_PYROSETTA.md
+++ b/containers/2_ApplicationSpecific/BindCraft/EXAMPLES_WITH_PYROSETTA.md
@@ -40,7 +40,7 @@ Note that the AlphaFold 2 params files are mounted on /app/params inside the con
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \
@@ -227,7 +227,7 @@ Start the container:
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \

--- a/containers/2_ApplicationSpecific/BindCraft/README.md
+++ b/containers/2_ApplicationSpecific/BindCraft/README.md
@@ -131,7 +131,7 @@ mkdir -p ./input ./output
 
 ```
 apptainer shell \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \

--- a/containers/2_ApplicationSpecific/BindCraft/slurm_BindCraft_example.bash
+++ b/containers/2_ApplicationSpecific/BindCraft/slurm_BindCraft_example.bash
@@ -57,7 +57,7 @@ then
   exit 1
 fi 
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B ./input:/work/input,./output:/work/output \
  --nv \
  ./BindCraft-$(arch).sif \
@@ -69,7 +69,7 @@ then
 fi
 
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \

--- a/containers/2_ApplicationSpecific/BindCraft/slurm_BindCraft_with_PyRosetta_example.bash
+++ b/containers/2_ApplicationSpecific/BindCraft/slurm_BindCraft_with_PyRosetta_example.bash
@@ -57,7 +57,7 @@ then
   exit 1
 fi 
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B ./input:/work/input,./output:/work/output \
  --nv \
  ./BindCraft-$(arch).sif \
@@ -69,7 +69,7 @@ then
 fi
 
 apptainer run \
- -B /projects:/projects,/scratch:/scratch,/util:/util,/vscratch:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects,/scratch:/scratch,/util:/util,/vscratch/grp-[YourGroupName]:/vscratch \
  -B /util/software/data/alphafold/params:/app/params \
  -B ./input:/work/input,./output:/work/output \
  --nv \

--- a/containers/2_ApplicationSpecific/Micro-C/EXAMPLES.md
+++ b/containers/2_ApplicationSpecific/Micro-C/EXAMPLES.md
@@ -9,7 +9,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --excl
 ...and started the container like this:
 
 ```
-apptainer shell -B /util:/util,/scratch:/scratch,/vscratch:/vscratch,/projects:/projects Micro-C-$(arch).sif
+apptainer shell -B /util:/util,/scratch:/scratch,/vscratch/grp-[YourGroupName]:/vscratch,/projects/academic/[YourGroupName]:/projects Micro-C-$(arch).sif
 ```
 
 Note: /util is mounted because there are datafiles already downloaded in the

--- a/containers/2_ApplicationSpecific/Micro-C/README.md
+++ b/containers/2_ApplicationSpecific/Micro-C/README.md
@@ -62,7 +62,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --mem=
 
 ```
 cd /projects/academic/[YourGroupName]/[CCRusername]
-apptainer shell -B /util:/util,/scratch:/scratch,/vscratch:/vscratch,/projects:/projects Micro-C-$(arch).sif
+apptainer shell -B /util:/util,/scratch:/scratch,/vscratch/grp-[YourGroupName]:/vscratch,/projects/academic/[YourGroupName]:/projects Micro-C-$(arch).sif
 ```
 Expected prompt:
 ```

--- a/containers/2_ApplicationSpecific/OpenFOAM/EXAMPLES.md
+++ b/containers/2_ApplicationSpecific/OpenFOAM/EXAMPLES.md
@@ -15,7 +15,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --mem=
 
 ```
 cd /projects/academic/[YourGroupName]/OpenFOAM
-apptainer shell -B /util:/util,/scratch:/scratch,/vscratch:/vscratch,/projects:/projects OpenFOAM-13-$(arch).sif
+apptainer shell -B /util:/util,/scratch:/scratch,/vscratch/grp-[YourGroupName]:/vscratch,/projects/academic/[YourGroupName]:/projects OpenFOAM-13-$(arch).sif
 ```
 
 sample output:
@@ -235,8 +235,8 @@ NOTE: This is NOT the same command as above, there are added bind mounts that
  are necessary to run paraFoam in CCR's OnDemand
 
 ```
-apptainer shell -B /util:/util -B /scratch:/scratch -B /vscratch:/vscratch \
- -B /projects:/projects -B ${XDG_RUNTIME_DIR}:${XDG_RUNTIME_DIR} \
+apptainer shell -B /util:/util -B /scratch:/scratch -B /vscratch/grp-[YourGroupName]:/vscratch \
+ -B /projects/academic/[YourGroupName]:/projects -B ${XDG_RUNTIME_DIR}:${XDG_RUNTIME_DIR} \
  -B /cvmfs:/cvmfs ./OpenFOAM-13-$(arch).sif
 ```
 

--- a/containers/2_ApplicationSpecific/OpenFOAM/README.md
+++ b/containers/2_ApplicationSpecific/OpenFOAM/README.md
@@ -71,7 +71,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --mem=
 
 ```
 cd /projects/academic/[YourGroupName]/OpenFOAM
-apptainer shell -B /util:/util,/scratch:/scratch,/vscratch:/vscratch,/projects:/projects OpenFOAM-13-$(arch).sif
+apptainer shell -B /util:/util,/scratch:/scratch,/vscratch/grp-[YourGroupName]:/vscratch,/projects/academic/[YourGroupName]:/projects OpenFOAM-13-$(arch).sif
 ```
 
 sample output:

--- a/containers/2_ApplicationSpecific/OpenFOAM/slurm_OpenFOAM_example.bash
+++ b/containers/2_ApplicationSpecific/OpenFOAM/slurm_OpenFOAM_example.bash
@@ -33,7 +33,7 @@
 if [ "${APPTAINER_NAME}" = "" ]
 then
   # Launch the container with this script
-  exec apptainer exec -B /util:/util,/scratch:/scratch,/vscratch:/vscratch,/projects:/projects \
+  exec apptainer exec -B /util:/util,/scratch:/scratch,/vscratch/grp-[YourGroupName]:/vscratch,/projects/academic/[YourGroupName]:/projects \
    /projects/academic/[YourGroupName]/OpenFOAM/OpenFOAM-13-$(arch).sif \
    bash "$(scontrol show job $SLURM_JOB_ID | awk -F= '/Command=/{print $2}')"
 fi

--- a/containers/2_ApplicationSpecific/OpenSees/BUILD-ARM64.md
+++ b/containers/2_ApplicationSpecific/OpenSees/BUILD-ARM64.md
@@ -64,7 +64,7 @@ exit
 sample output:
 
 > ```
-> CCRusername@login1$ 
+> CCRusername@login1$
 > ```
 
 End the Slurm job
@@ -96,13 +96,13 @@ cd /projects/academic/[YourGroupName]/OpenSees
 ...then start the OpenSees container instance
 
 ```
-apptainer shell -B /util:/util,/scratch:/scratch,/projects:/projects OpenSees-$(arch).sif 
+apptainer shell -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects OpenSees-$(arch).sif
 ```
 
 expected output:
 
 > ```
-> Apptainer> 
+> Apptainer>
 > ```
 
 The following command is run from the "Apptainer> " prompt
@@ -114,18 +114,18 @@ OpenSees
 expected output:
 
 > ```
-> 
-> 
+>
+>
 >          OpenSees -- Open System For Earthquake Engineering Simulation
 >                  Pacific Earthquake Engineering Research Center
 >                         Version 3.7.2 64-Bit
-> 
+>
 >       (c) Copyright 1999-2016 The Regents of the University of California
 >                               All Rights Reserved
 >   (Copyright and Disclaimer @ http://www.berkeley.edu/OpenSees/copyright.html)
-> 
-> 
-> OpenSees > 
+>
+>
+> OpenSees >
 > ```
 
 Exit OpenSees
@@ -137,7 +137,7 @@ exit
 expected output:
 
 > ```
-> Apptainer> 
+> Apptainer>
 > ```
 
 Exit the Apptainer container instance
@@ -149,7 +149,7 @@ exit
 sample outout:
 
 > ```
-> CCRusername@cpn-v14-19$ 
+> CCRusername@cpn-v14-19$
 > ```
 
 Exit the Slurm interactive session
@@ -161,7 +161,7 @@ exit
 sample output:
 
 > ```
-> CCRusername@login1$ 
+> CCRusername@login1$
 > ```
 
 End the Slurm job

--- a/containers/2_ApplicationSpecific/OpenSees/EXAMPLES.md
+++ b/containers/2_ApplicationSpecific/OpenSees/EXAMPLES.md
@@ -15,7 +15,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --excl
 ...and started the container like this:
 
 ```
-apptainer shell -B /util:/util,/scratch:/scratch,/projects:/projects /path/to/OpenSees-$(arch).sif 
+apptainer shell -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects /path/to/OpenSees-$(arch).sif
 Apptainer>
 ```
 
@@ -40,17 +40,17 @@ OpenSees ECP_example.tcl
 expected output:
 
 > ```
-> 
-> 
+>
+>
 >          OpenSees -- Open System For Earthquake Engineering Simulation
 >                  Pacific Earthquake Engineering Research Center
 >                         Version 3.7.2 64-Bit
-> 
+>
 >       (c) Copyright 1999-2016 The Regents of the University of California
 >                               All Rights Reserved
 >   (Copyright and Disclaimer @ http://www.berkeley.edu/OpenSees/copyright.html)
-> 
-> 
+>
+>
 > Done!
 > ```
 
@@ -111,16 +111,16 @@ OpenSees pushover_concentrated.tcl
 sample output:
 
 > ```
-> 
+>
 >          OpenSees -- Open System For Earthquake Engineering Simulation
 >                  Pacific Earthquake Engineering Research Center
 >                         Version 3.7.2 64-Bit
-> 
+>
 >       (c) Copyright 1999-2016 The Regents of the University of California
 >                               All Rights Reserved
 >   (Copyright and Disclaimer @ http://www.berkeley.edu/OpenSees/copyright.html)
-> 
-> 
+>
+>
 > WARNING: DO NOT USE THE "Bilin" MATERIAL, IT HAS BEEN REPLACED. Use "IMKBilin" or "HystereticSM" INSTEAD.
 > ProfileSPDLinDirectSolver::solve() -  aii < 0 (i, aii): (9, 0)
 > T1 = 0.8198074473990256 s
@@ -163,16 +163,16 @@ OpenSees pushover_distributed.tcl
 sample output:
 
 > ```
-> 
+>
 >          OpenSees -- Open System For Earthquake Engineering Simulation
 >                  Pacific Earthquake Engineering Research Center
 >                         Version 3.7.2 64-Bit
-> 
+>
 >       (c) Copyright 1999-2016 The Regents of the University of California
 >                               All Rights Reserved
 >   (Copyright and Disclaimer @ http://www.berkeley.edu/OpenSees/copyright.html)
-> 
-> 
+>
+>
 > WARNING: DO NOT USE THE "Bilin" MATERIAL, IT HAS BEEN REPLACED. Use "IMKBilin" or "HystereticSM" INSTEAD.
 > ProfileSPDLinDirectSolver::solve() -  aii < minDiagTol (i, aii): (6, -6.82121e-13)
 > T1 = 0.8199912211464974 s
@@ -218,7 +218,7 @@ curl -o ElasticTruss.py  https://openseespydoc.readthedocs.io/en/latest/_downloa
 Run the python script:
 
 ```
-python ElasticTruss.py 
+python ElasticTruss.py
 ```
 
 expected output:

--- a/containers/2_ApplicationSpecific/OpenSees/GUI_EXAMPLES.md
+++ b/containers/2_ApplicationSpecific/OpenSees/GUI_EXAMPLES.md
@@ -38,7 +38,7 @@ cd /projects/academic/[YourGroupName]/OpenSees/test-x86_64
 (change the path to your OpenSees .sif file)
 
 ```
-apptainer shell -B /util:/util,/scratch:/scratch,/projects:/projects \
+apptainer shell -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  /projects/academic/[YourGroupName]/OpenSees/OpenSees-$(arch).sif
 ```
 

--- a/containers/2_ApplicationSpecific/OpenSees/PARALLEL_EXAMPLES.md
+++ b/containers/2_ApplicationSpecific/OpenSees/PARALLEL_EXAMPLES.md
@@ -69,7 +69,7 @@ command output:
 >  --nodes=${SLURM_NNODES} \
 >  --ntasks-per-node=${SLURM_NTASKS_PER_NODE} \
 >  apptainer exec \
->  -B /util:/util,/scratch:/scratch,/projects:/projects \
+>  -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
 >  --sharens \
 >  /projects/academic/ccradmintest/tkewtest/OpenSees/OpenSees-$(arch).sif \
 >  OpenSeesSP Example.tcl
@@ -211,7 +211,7 @@ command output:
 >  --nodes=${SLURM_NNODES} \
 >  --ntasks-per-node=${SLURM_NTASKS_PER_NODE} \
 >  apptainer exec \
->  -B /util:/util,/scratch:/scratch,/projects:/projects \
+>  -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
 >  --sharens \
 >  /projects/academic/ccradmintest/tkewtest/OpenSees/OpenSees-$(arch).sif \
 >  OpenSeesMP Example.tcl

--- a/containers/2_ApplicationSpecific/OpenSees/README.md
+++ b/containers/2_ApplicationSpecific/OpenSees/README.md
@@ -77,7 +77,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --mem=
 
 ```
 cd /projects/academic/[YourGroupName]/
-apptainer shell -B /util:/util,/scratch:/scratch,/projects:/projects OpenSees-$(arch).sif 
+apptainer shell -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects OpenSees-$(arch).sif
 Apptainer> OpenSees
 
 
@@ -90,7 +90,7 @@ Apptainer> OpenSees
   (Copyright and Disclaimer @ http://www.berkeley.edu/OpenSees/copyright.html)
 
 
-OpenSees > 
+OpenSees >
 ```
 
 ## Parallel OpenSees
@@ -105,18 +105,18 @@ Parallel MPI jobs can be run with OpenSeesSP or OpenSeesMP
 
 Parallel Slurm script examples (X86_64):
 
-[mainSP with "srun"](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_example.bash)  
+[mainSP with "srun"](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_example.bash)
 [mainSP with "mpirun"](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_mpirun_example.bash)
 
-[mainMP with "srun"](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_example.bash)  
+[mainMP with "srun"](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_example.bash)
 [mainMP with "mpirun"](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_mpirun_example.bash)
 
 Parallel ARM64 Slurm script examples:
 
-[mainSP](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesSP_example.bash)  
+[mainSP](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesSP_example.bash)
 [mainMP](https://raw.githubusercontent.com/ubccr/ccr-examples/refs/heads/main/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesMP_example.bash)
 
 
-See the [OpenSees Documentation](https://opensees.github.io/OpenSeesDocumentation) website and the [OpenSees Parallel](https://opensees.berkeley.edu/OpenSees/parallel/parallel.php) website for more info on OpenSees  
+See the [OpenSees Documentation](https://opensees.github.io/OpenSeesDocumentation) website and the [OpenSees Parallel](https://opensees.berkeley.edu/OpenSees/parallel/parallel.php) website for more info on OpenSees
 For the Python documentation see the [OpenSeesPy](https://openseespydoc.readthedocs.io) website
 

--- a/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesMP_example.bash
+++ b/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesMP_example.bash
@@ -47,7 +47,7 @@ srun --mpi=pmix \
  --nodes=${SLURM_NNODES} \
  --ntasks-per-node=${SLURM_NTASKS_PER_NODE} \
  $(which apptainer) exec \
- -B /util:/util,/scratch:/scratch,/projects:/projects \
+ -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  --sharens \
  /path/to/OpenSees-$(arch).sif \
  OpenSeesMP Example.tcl

--- a/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesSP_example.bash
+++ b/containers/2_ApplicationSpecific/OpenSees/slurm_ARM64_OpenSeesSP_example.bash
@@ -47,7 +47,7 @@ srun --mpi=pmix \
  --nodes=${SLURM_NNODES} \
  --ntasks-per-node=${SLURM_NTASKS_PER_NODE} \
  $(which apptainer) exec \
- -B /util:/util,/scratch:/scratch,/projects:/projects \
+ -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  --sharens \
  /path/to/OpenSees-$(arch).sif \
  OpenSeesSP Example.tcl

--- a/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_example.bash
+++ b/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_example.bash
@@ -52,7 +52,7 @@ srun --mpi=pmix \
  --nodes=${SLURM_NNODES} \
  --ntasks-per-node=${SLURM_NTASKS_PER_NODE} \
  apptainer exec \
- -B /util:/util,/scratch:/scratch,/projects:/projects \
+ -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  --sharens \
  /path/to/OpenSees-$(arch).sif \
  OpenSeesMP Example.tcl

--- a/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_mpirun_example.bash
+++ b/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesMP_mpirun_example.bash
@@ -50,7 +50,7 @@ export OMPI_MCA_btl="self,vader,ofi"
 mpirun --mca pml ucx --mca btl self,vader,ofi --map-by core \
  --mca orte_base_help_aggregate 0 \
  -np ${SLURM_NTASKS} apptainer exec \
- -B /util:/util,/scratch:/scratch,/projects:/projects \
+ -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  --sharens \
  /path/to/OpenSees-$(arch).sif \
  OpenSeesMP Example.tcl

--- a/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_example.bash
+++ b/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_example.bash
@@ -52,7 +52,7 @@ srun --mpi=pmix \
  --nodes=${SLURM_NNODES} \
  --ntasks-per-node=${SLURM_NTASKS_PER_NODE} \
  apptainer exec \
- -B /util:/util,/scratch:/scratch,/projects:/projects \
+ -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  --sharens \
  /path/to/OpenSees-$(arch).sif \
  OpenSeesSP Example.tcl

--- a/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_mpirun_example.bash
+++ b/containers/2_ApplicationSpecific/OpenSees/slurm_OpenSeesSP_mpirun_example.bash
@@ -44,7 +44,7 @@ module load gcc openmpi
 mpirun --mca pml ucx --mca btl self,vader,ofi --map-by core \
  --mca orte_base_help_aggregate 0 \
  -np ${SLURM_NTASKS} apptainer exec \
- -B /util:/util,/scratch:/scratch,/projects:/projects \
+ -B /util:/util,/scratch:/scratch,/projects/academic/[YourGroupName]:/projects \
  --sharens \
  /path/to/OpenSees-$(arch).sif \
  OpenSeesSP Example.tcl

--- a/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/README.md
+++ b/containers/2_ApplicationSpecific/Open_Force_Field_toolkit/README.md
@@ -63,7 +63,7 @@ salloc --cluster=ub-hpc --partition=general-compute --qos=general-compute --mem=
 
 ```
 cd /projects/academic/[YourGroupName]/[CCRusername]
-apptainer exec -B /scratch:/scratch,/projects:/projects openff-toolkit-$(arch).sif python
+apptainer exec -B /scratch:/scratch,/projects/academic/[YourGroupName]:/projects openff-toolkit-$(arch).sif python
 ```
 Expected output:
 ```
@@ -75,7 +75,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 Alternatively, you can first get shell access into the container, as shown here:
 
 ```
-apptainer shell -B /scratch:/scratch,/projects:/projects openff-toolkit-$(arch).sif
+apptainer shell -B /scratch:/scratch,/projects/academic/[YourGroupName]:/projects openff-toolkit-$(arch).sif
 ```
 And then run Python from the "Apptainer>" prompt:
 ```


### PR DESCRIPTION
## Summary

This PR updates the application-specific container documentation and example scripts to use subgroup-specific bind mounts instead of mounting the top-level `/projects` and `/vscratch` directories.

### Changes

- Replaced:
  - `/projects:/projects`
  - `/vscratch:/vscratch`

- With:
  - `/projects/academic/[YourGroupName]:/projects`
  - `/vscratch/grp-[YourGroupName]:/vscratch`